### PR TITLE
chore(data): new package za.co.lazygamedev.rogue-dots

### DIFF
--- a/data/packages/za.co.lazygamedev.rogue-dots.yml
+++ b/data/packages/za.co.lazygamedev.rogue-dots.yml
@@ -1,0 +1,15 @@
+name: za.co.lazygamedev.rogue-dots
+displayName: LazyGameDevZA's RogueDOTS
+description: null
+repoUrl: 'https://github.com/LazyGameDevZA/RogueDOTS'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - 2d
+  - dots
+  - utility
+hunter: sasvdw
+gitTagIgnore: ''
+image: null
+createdAt: 1580199771165


### PR DESCRIPTION
I'm currently working on a port of the  Roguelike tutorial by TheBracket's really good Rust tutorial series (details are in my package repository). It's still very early in development, but having it available on a package registry should contribute a great deal towards easily enabling others to test out what I'd built.