### PR TITLE
Update com.cysharp.unitask to use the main repo

### DIFF
--- a/data/packages/com.cysharp.unitask.yml
+++ b/data/packages/com.cysharp.unitask.yml
@@ -1,8 +1,7 @@
 name: com.cysharp.unitask
 displayName: UniTask
 description: Provides an efficient async/await integration to Unity.
-repoUrl: 'https://github.com/starikcetin/UniTask'
-parentRepoUrl: 'https://github.com/Cysharp/UniTask'
+repoUrl: 'https://github.com/Cysharp/UniTask'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:


### PR DESCRIPTION
The main UniTask repo now has [direct support for UPM](https://github.com/Cysharp/UniTask#upm-package) via the `Assets/UniRx.Async` subfolder. OpenUPM is able to handle this setup directly, so it should no longer be necessary to use a fork for UPM support.

@starikcetin I'm guessing that UPM support was added since you initially added UniTask to OpenUPM. Assuming that the updated configuration works, you should be good to delete your fork 😄 