### PR TITLE
Json.NET Converters, Added tag prefix

### DIFF
--- a/data/packages/jillejr.newtonsoft.json-for-unity.converters.yml
+++ b/data/packages/jillejr.newtonsoft.json-for-unity.converters.yml
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - utilities
 hunter: jilleJr
-gitTagPrefix: ''
+gitTagPrefix: upm/
 gitTagIgnore: ''
 image: null
 createdAt: 1588528711172


### PR DESCRIPTION
Too scared of causing harm if I change the existing tags in the Newtonsoft.Json-for-Unity repo, so going with the suggested `upm/` prefix there. Then also mimicing that here.

I feel it very unnatural anyway to use tags to point to a built version of the product, so I'd rather have it stand out like it now does with the `upm/` prefix.

Hope it doesn't weird out the OpenUPM registry.
I only had a preview build deployed anyway, so I'm thinking if it blows up then just remove it.