### PR TITLE
chore(data): new package jillejr.newtonsoft.json-for-unity

### DIFF
--- a/data/packages/jillejr.newtonsoft.json-for-unity.yml
+++ b/data/packages/jillejr.newtonsoft.json-for-unity.yml
@@ -1,0 +1,15 @@
+name: jillejr.newtonsoft.json-for-unity
+displayName: Json.NET 12.0.3 for Unity
+description: Newtonsoft.Json (Json.NET) 12.0.3 for Unity via Unity Package Manager
+repoUrl: 'https://github.com/jilleJr/Newtonsoft.Json-for-Unity'
+parentRepoUrl: 'https://github.com/JamesNK/Newtonsoft.Json'
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - utilities
+hunter: iDreamsOfGame
+gitTagPrefix: ''
+gitTagIgnore: ''
+image: null
+readme: 'upm:README.md'
+createdAt: 1589131258967


### PR DESCRIPTION
I had a small chat with @iDreamsOfGame and he said he was ok with me uploading my package even though he already added it.

He said he will remove his package from OpenUPM once mine is deployed.

I still kept him as hunter because he was first after all.

Side question: I already have multiple releases available, but will this only build the latest tag (12.0.301)? Just curious; the other versions shouldn't be used anyway since the newer version contains more bug fixes.

Cheers!