### PR TITLE
Update Yarn Spinner

### DIFF
--- a/data/packages/dev.secretlab.yarnspinner.yml
+++ b/data/packages/dev.secretlab.yarnspinner.yml
@@ -9,7 +9,7 @@ topics:
   - level-design
 hunter: JesseTG
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: '-beta'
 image: >-
   https://yarnspinner.dev/img/YarnSpinnerLogo.png
 readme: 'master:README.md'

--- a/data/packages/dev.secretlab.yarnspinner.yml
+++ b/data/packages/dev.secretlab.yarnspinner.yml
@@ -1,16 +1,16 @@
 name: dev.secretlab.yarnspinner
 displayName: Yarn Spinner
 description: Yarn Spinner is a tool for building interactive dialogue in games!
-repoUrl: 'https://github.com/YarnSpinnerTool/YarnSpinner'
+repoUrl: 'https://github.com/YarnSpinnerTool/YarnSpinner-Unity'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
   - level-design
 hunter: JesseTG
-gitTagPrefix: 'upm'
+gitTagPrefix: ''
 gitTagIgnore: ''
 image: >-
-  https://github.com/YarnSpinnerTool/YarnSpinner/raw/902ec6a38185436c0f3ef4fda8783075307fdadf/Unity/Assets/YarnSpinner/Editor/Icons/YarnSpinnerLogo.png
+  https://yarnspinner.dev/img/YarnSpinnerLogo.png
 readme: 'master:README.md'
 createdAt: 1588965131408


### PR DESCRIPTION
The Unity integration for Yarn Spinner has moved to a new repo. This PR updates the OpenUPM data to point to it.