### PR TITLE
chore(data): new package com.mefistofiles.unity-event-visualizer

### DIFF
--- a/data/packages/com.mefistofiles.unity-event-visualizer.yml
+++ b/data/packages/com.mefistofiles.unity-event-visualizer.yml
@@ -1,17 +1,17 @@
 name: com.mefistofiles.unity-event-visualizer
 displayName: Unity Event Visualizer
 description: A graph editor for viewing all UnityEvents at a glance
-repoUrl: 'https://github.com/Bullrich/UnityEventVisualizer'
-parentRepoUrl: 'https://github.com/MephestoKhaan/UnityEventVisualizer'
+repoUrl: 'https://github.com/MephestoKhaan/UnityEventVisualizer'
+parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
+topics: 
   - editor-enhancement
   - gui
-hunter: JesseTG
+hunter: Bullrich
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: '1.4.2'
 image: 'https://camo.githubusercontent.com/169dbaaa95afeac5044c17022d98878facc83ce7/68747470733a2f2f6d656469612e67697068792e636f6d2f6d656469612f63413356556957543046496c4b65624352532f67697068792e676966'
-readme: 'upm-generation:README.md'
+readme: 'master:Assets/EventVisualizer/ReadMe.md'
 createdAt: 1591476351373


### PR DESCRIPTION
Fixed event visualizer to point to the correct parent instead of my fork