### PR TITLE
Fixed parent repo in DTValidator

### DIFF
--- a/data/packages/at.innerspace.dtvalidator.yml
+++ b/data/packages/at.innerspace.dtvalidator.yml
@@ -4,7 +4,7 @@ description: >-
   Tool for validating objects (eg. GameObjects, ScriptableObjects, etc) in the
   Unity Editor.
 repoUrl: 'https://github.com/innerspacetrainings/DTValidator'
-parentRepoUrl: 'https://github.com/MarleneMayr/DTValidator'
+parentRepoUrl: 'https://github.com/DarrenTsung/DTValidator'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:


### PR DESCRIPTION
Fixed parent repo in DTValidator. Our repository is based on https://github.com/DarrenTsung/DTValidator instead of https://github.com/MarleneMayr/DTValidator (although it is a nested fork)