### PR TITLE
Update com.uap.unitytimelineevents.yml

### DIFF
--- a/data/packages/com.uap.unitytimelineevents.yml
+++ b/data/packages/com.uap.unitytimelineevents.yml
@@ -6,7 +6,7 @@ description: >-
 repoUrl: 'https://github.com/UnityAssetPackages/UnityTimelineEvents'
 parentRepoUrl: 'https://github.com/georgejecook/UnityTimelineEvents'
 licenseSpdxId: null
-licenseName: Unknown
+licenseName: ''
 topics:
   - animation
 hunter: JesseTG


### PR DESCRIPTION
- Use blank string instead of "Unknown" to denote absent license