### PR TITLE
Move package com.kurtgokhan.react-unity to com.reactunity.core

### DIFF
--- a/data/packages/com.reactunity.core.yml
+++ b/data/packages/com.reactunity.core.yml
@@ -1,7 +1,7 @@
-name: com.kurtgokhan.react-unity
+name: com.reactunity.core
 displayName: React Unity
 description: React renderer for building user interfaces in Unity UI
-repoUrl: 'https://github.com/KurtGokhan/react-unity'
+repoUrl: 'https://github.com/ReactUnity/core'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -11,5 +11,5 @@ topics:
 hunter: KurtGokhan
 gitTagPrefix: ''
 gitTagIgnore: ''
-image: null
+image: 'https://avatars2.githubusercontent.com/u/62178684'
 createdAt: 1584361495094

--- a/data/packages/com.reactunity.core.yml
+++ b/data/packages/com.reactunity.core.yml
@@ -11,5 +11,6 @@ topics:
 hunter: KurtGokhan
 gitTagPrefix: ''
 gitTagIgnore: ''
+minVersion: 0.0.13
 image: 'https://avatars2.githubusercontent.com/u/62178684'
 createdAt: 1584361495094


### PR DESCRIPTION
Changes are because I moved my repo under an organization https://github.com/ReactUnity

I hope renaming the repo works well and does not break anything.