### PR TITLE
Update com.abxy.roslyn.yml

### DIFF
--- a/data/packages/com.abxy.roslyn.yml
+++ b/data/packages/com.abxy.roslyn.yml
@@ -1,5 +1,5 @@
 name: com.abxy.roslyn
-displayName: '".NET Compiler Platform ("Roslyn")"'
+displayName: NET Compiler Platform (Roslyn)
 description: The Microsoft C# binaries compiled for Unity
 repoUrl: 'https://github.com/mwahnish/Unity-Roslyn'
 parentRepoUrl: null


### PR DESCRIPTION
Display name contained illegal file path characters which caused issues when inspecting package contents in editor