### PR TITLE
chore(data): new package System.Runtime.CompilerServices.Unsafe.dll

### DIFF
--- a/data/packages/System.Runtime.CompilerServices.Unsafe.dll.yml
+++ b/data/packages/System.Runtime.CompilerServices.Unsafe.dll.yml
@@ -1,0 +1,15 @@
+name: System.Runtime.CompilerServices.Unsafe.dll
+displayName: System.Runtime.CompilerServices.Unsafe.dll
+description: null
+repoUrl: 'https://github.com/sebas77/com.sebaslab.svelto.unsafe'
+parentRepoUrl: null
+licenseSpdxId: null
+licenseName: ''
+topics: []
+hunter: ''
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'master:README.md'
+createdAt: 1604240311895


### PR DESCRIPTION
Unity collection doesn't include Unsafe.dll anymore. A new way to distribute the file must be found. I am experimenting using openUPM to do so.