### PR TITLE
chore(data): new package com.dopamine.firebase.core

### DIFF
--- a/data/packages/com.dopamine.firebase.core.yml
+++ b/data/packages/com.dopamine.firebase.core.yml
@@ -1,0 +1,19 @@
+name: com.dopamine.firebase.core
+displayName: Firebase Core
+description: Latest Version of firebase
+repoUrl: 'https://github.com/dopaminegamesstudio/Firebase.Core'
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+topics:
+  - utilities
+hunter: ''
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'master:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1612259492778


### PR DESCRIPTION
Currently, google. firebase modules are very old and do not seem going to be updated any time soon.

As a workaround, We upgrade them manually