### PR TITLE
Update com.unity.project-auditor.yml

### DIFF
--- a/data/packages/com.unity.project-auditor.yml
+++ b/data/packages/com.unity.project-auditor.yml
@@ -1,10 +1,10 @@
 name: com.unity.project-auditor
 displayName: Project Auditor
 description: Project Auditor is an experimental static analysis tool for Unity Projects.
-repoUrl: 'https://github.com/mtrive/ProjectAuditor'
-parentRepoUrl: null
-licenseSpdxId: MIT
-licenseName: MIT License
+repoUrl: 'https://github.com/Unity-Technologies/ProjectAuditor'
+parentRepoUrl: 'https://github.com/mtrive/ProjectAuditor'
+licenseSpdxId: UDP
+licenseName: Unity Package Distribution License
 topics:
   - utilities
 hunter: favoyang

--- a/data/packages/com.unity.project-auditor.yml
+++ b/data/packages/com.unity.project-auditor.yml
@@ -3,7 +3,7 @@ displayName: Project Auditor
 description: Project Auditor is an experimental static analysis tool for Unity Projects.
 repoUrl: 'https://github.com/Unity-Technologies/ProjectAuditor'
 parentRepoUrl: 'https://github.com/mtrive/ProjectAuditor'
-licenseSpdxId: UDP
+licenseSpdxId: null
 licenseName: Unity Package Distribution License
 topics:
   - utilities


### PR DESCRIPTION
Unity has moved the development of the Project Auditor package to a new repository. They're planning on adding it to the Unity Package Manager, but it's not there yet.