### PR TITLE
chore(data): new package com.appalachia.unity3d.editor.preferences.easy

### DIFF
--- a/data/packages/com.appalachia.unity3d.editor.preferences.easy.yml
+++ b/data/packages/com.appalachia.unity3d.editor.preferences.easy.yml
@@ -1,0 +1,26 @@
+name: com.appalachia.unity3d.editor.preferences.easy
+displayName: Easy Editor Preferences for Unity3D
+description: >-
+  Automatically creates, updates, and draws custom Editor Preferences in the
+  Settings window. Supports bool, float, int, string, as well as enums
+  (int-backed) and color.
+repoUrl: >-
+  https://github.com/AppalachiaInteractive/com.appalachia.unity3d.editor.preferences.easy
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - code-generation
+  - editor-enhancement
+  - frameworks
+  - utilities
+hunter: ChristopherSchubert
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.2
+image: null
+readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1620345633474


### PR DESCRIPTION
Hi,
This is a simple Unity3D editor framework which provides a few types, such as `BoolEditorPref` (and others).  These can be used as a replacement for `bool`, and the framework will automatically add them to the Editor Preferences, and show them in the Settings window.  There is some fancy formatting and buttons you can generate as well.