### PR TITLE
Update project image

### DIFF
--- a/data/packages/id.instance.projectplanner.yml
+++ b/data/packages/id.instance.projectplanner.yml
@@ -14,7 +14,7 @@ hunter: instance-id
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
-image: null
+image: 'https://raw.githubusercontent.com/instance-id/Project-Planner/master/readme%20image.png'
 readme: 'upm:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''


### PR DESCRIPTION
I always miss/forget the project image. Is there a way to have it be part of the "new package" setup process? Such as just a box with a label on the "Add Package" page of OpenUPM? Simply seeing it during the setup process would certainly help in remembering that it exists.