### PR TITLE
chore(data): new package com.fredericrp.stringdatalist

### DIFF
--- a/data/packages/com.fredericrp.stringdatalist.yml
+++ b/data/packages/com.fredericrp.stringdatalist.yml
@@ -1,0 +1,26 @@
+name: com.fredericrp.stringdatalist
+displayName: FRP String Data List
+description: >-
+  Let say you want to allow your designer to edit some string properties in your
+  project (you, fool) but there are only a limited amount of allowed strings,
+  like characters names, seasons or anything, and for whatever reason, you don't
+  want or cannot use enums. Or maybe you have a list of data, and you don't want
+  to have a name property of each data nor you want the list to display -Element
+  0-, -Element 1-, but instead you want to use your own names: for instance Cat,
+  dog, unicorn... This is the asset for you.
+repoUrl: 'https://github.com/FredericRP/StringDataList'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - editor-enhancement
+hunter: FredericRP
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'primary:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1634154237603


### PR DESCRIPTION
Let say you want to allow your designer to edit some string properties in your project (you, fool) but there are only a limited amount of allowed strings,
  like characters names, seasons or anything, and for whatever reason, you don't want or cannot use enums. Or maybe you have a list of data, and you don't want
  to have a name property of each data nor do you want the list to display -Element 0-, -Element 1-, but instead you want to use your own names: for instance Cat,
  dog, unicorn... This is an asset for you.