### PR TITLE
chore(data): new package de.awesome-co.playconfiguration

### DIFF
--- a/data/packages/de.awesome-co.playconfiguration.yml
+++ b/data/packages/de.awesome-co.playconfiguration.yml
@@ -1,0 +1,19 @@
+name: de.awesome-co.playconfiguration
+displayName: Play Configuration
+description: Closes or opens selected scenes when entering playback mode (editor only).
+repoUrl: 'https://github.com/Herb1/PlayConfiguration'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - editor-enhancement
+hunter: ''
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'master:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1636146971917


### PR DESCRIPTION
With this package you can select which scenes should be loaded/unloaded when entering the playmode. Useful when scenes are loaded by other scenes at runtime.