### PR TITLE
fix gitTagPrefix of cc.starlessnight.unity-jsb

### DIFF
--- a/data/packages/cc.starlessnight.unity-jsb.yml
+++ b/data/packages/cc.starlessnight.unity-jsb.yml
@@ -9,7 +9,7 @@ topics:
   - editor-enhancement
   - utilities
 hunter: ialex32x
-gitTagPrefix: upm/x.y.z
+gitTagPrefix: upm/
 gitTagIgnore: ''
 minVersion: ''
 image: null


### PR DESCRIPTION
fix gitTagPrefix of cc.starlessnight.unity-jsb