### PR TITLE
chore(data): new package com.rhinox.open.perceptor

### DIFF
--- a/data/packages/com.rhinox.open.perceptor.yml
+++ b/data/packages/com.rhinox.open.perceptor.yml
@@ -1,0 +1,21 @@
+name: com.rhinox.open.perceptor
+displayName: 'Perceptor - Unity Logging Framework'
+description: Unity Logging Framework built by Rhinox
+repoUrl: 'https://github.com/Rhinox-Training/rhinox-perceptor'
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+topics:
+  - debugging-and-logging
+  - testing
+  - utilities
+hunter: GDGRhinox
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'master:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1645632105179


### PR DESCRIPTION
This package (small logging framework) has been actively used in our company, now we're making the move to make some of our internal libraries/frameworks open source.