### PR TITLE
chore(data): update package com.community.netcode.transport.websocket.yml

### DIFF
--- a/data/packages/com.community.netcode.transport.websocket.yml
+++ b/data/packages/com.community.netcode.transport.websocket.yml
@@ -1,18 +1,18 @@
 name: com.community.netcode.transport.websocket
 displayName: WebSocket Transport for Netcode for GameObjects
 description: WebSocket Transport for Netcode for GameObjects
-repoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
-parentRepoUrl: null
+repoUrl: 'https://github.com/CareBoo/multiplayer-community-contributions'
+parentRepoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
   - network
 hunter: jasonboukheir
-gitTagPrefix: ''
+gitTagPrefix: 'com.community.netcode.transport.websocket/'
 gitTagIgnore: ''
 minVersion: ''
 image: null
-readme: 'main:Transports/com.community.netcode.transport.websocket/README.md'
+readme: 'main:Packages/com.community.netcode.transport.websocket/README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''


### PR DESCRIPTION
fixes the issue where git tags can't be found by using a forked repository

https://github.com/Unity-Technologies/multiplayer-community-contributions/issues/101