### PR TITLE
chore(data): update package com.mlapi.contrib.transport.litenetlib.yml

### DIFF
--- a/data/packages/com.mlapi.contrib.transport.litenetlib.yml
+++ b/data/packages/com.mlapi.contrib.transport.litenetlib.yml
@@ -1,18 +1,18 @@
 name: com.mlapi.contrib.transport.litenetlib
 displayName: LiteNetLib Transport for MLAPI
 description: LiteNetLib Transport for MLAPI
-repoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
-parentRepoUrl: null
+repoUrl: 'https://github.com/CareBoo/multiplayer-community-contributions'
+parentRepoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
   - network
 hunter: SushiWaUmai
-gitTagPrefix: ''
+gitTagPrefix: 'com.mlapi.contrib.transport.litenetlib/'
 gitTagIgnore: ''
 minVersion: ''
 image: null
-readme: 'master:README.md'
+readme: 'main:Packages/com.mlapi.contrib.transport.litenetlib/README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''


### PR DESCRIPTION
fixes the issue where git tags can't be found by using a forked repository.

https://github.com/Unity-Technologies/multiplayer-community-contributions/issues/101