### PR TITLE
chore(data): update package com.mlapi.contrib.transport.enet.yml

### DIFF
--- a/data/packages/com.mlapi.contrib.transport.enet.yml
+++ b/data/packages/com.mlapi.contrib.transport.enet.yml
@@ -2,17 +2,17 @@ name: com.mlapi.contrib.transport.enet
 displayName: ENET Transport for MLAPI
 description: ENET Transport for MLAPI
 repoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
-parentRepoUrl: null
+parentRepoUrl: 'https://github.com/CareBoo/multiplayer-community-contributions'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
   - network
 hunter: SushiWaUmai
-gitTagPrefix: ''
+gitTagPrefix: 'com.mlapi.contrib.transport.enet/'
 gitTagIgnore: ''
 minVersion: ''
 image: null
-readme: 'master:README.md'
+readme: 'main:Packages/com.mlapi.contrib.transport.enet/README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''

--- a/data/packages/com.mlapi.contrib.transport.enet.yml
+++ b/data/packages/com.mlapi.contrib.transport.enet.yml
@@ -1,8 +1,8 @@
 name: com.mlapi.contrib.transport.enet
 displayName: ENET Transport for MLAPI
 description: ENET Transport for MLAPI
-repoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
-parentRepoUrl: 'https://github.com/CareBoo/multiplayer-community-contributions'
+repoUrl: 'https://github.com/CareBoo/multiplayer-community-contributions'
+parentRepoUrl: 'https://github.com/Unity-Technologies/multiplayer-community-contributions'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:


### PR DESCRIPTION
fixes the issue where git tags can't be found by using a forked repository

https://github.com/Unity-Technologies/multiplayer-community-contributions/issues/101