### PR TITLE
Set up tag ignore and prefix for Responsible

### DIFF
--- a/data/packages/com.beatwaves.responsible.yml
+++ b/data/packages/com.beatwaves.responsible.yml
@@ -8,8 +8,8 @@ licenseName: MIT License
 topics:
   - testing
 hunter: JesseTG
-gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagPrefix: 'v'
+gitTagIgnore: 'responsible-gherkin'
 minVersion: ''
 image: null
 readme: 'main:README.md'


### PR DESCRIPTION
I started publishing another NuGet package (responsible-gherkin) from the same repo, so this should help with the unnecessary builds.