### PR TITLE
chore(data): new package com.rhinox.open.robotics.vhacd

### DIFF
--- a/data/packages/com.rhinox.open.robotics.vhacd.yml
+++ b/data/packages/com.rhinox.open.robotics.vhacd.yml
@@ -1,0 +1,19 @@
+name: com.rhinox.open.robotics.vhacd
+displayName: VHACD - Unity Fork
+description: Mesh decomposition algorithm forked from Unity VHACD
+repoUrl: 'https://github.com/Rhinox-Training/VHACD'
+parentRepoUrl: 'https://github.com/Unity-Technologies/VHACD'
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+topics:
+  - physics
+hunter: GDGRhinox
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'upm:Runtime/LICENSE.MD'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1659442871138


### PR DESCRIPTION
Adding a forked version of UnityTechnologies/V-HACD which adheres to the OpenUPM repo structure