### PR TITLE
chore(data): new package com.unity-atoms.unity-atoms-input-system

### DIFF
--- a/data/packages/com.unity-atoms.unity-atoms-input-system.yml
+++ b/data/packages/com.unity-atoms.unity-atoms-input-system.yml
@@ -1,0 +1,20 @@
+name: com.unity-atoms.unity-atoms-input-system
+displayName: Unity Atoms Input System
+description: Unity Atoms with Unity's Input System.
+repoUrl: 'https://github.com/unity-atoms/unity-atoms'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - data-management
+  - utilities
+hunter: AdamRamberg
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'master:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1666642716392


### PR DESCRIPTION
The Input System subpackage of Unity Atoms is missing from OpenUPM. 

For reference: https://github.com/unity-atoms/unity-atoms/issues/355