### PR TITLE
chore(data): new package com.github.ivanmurzak.ios.pods.bitcode

### DIFF
--- a/data/packages/com.github.ivanmurzak.ios.pods.bitcode.yml
+++ b/data/packages/com.github.ivanmurzak.ios.pods.bitcode.yml
@@ -1,0 +1,22 @@
+name: com.github.ivanmurzak.ios.pods.bitcode
+displayName: iOS Pods Bitcode
+description: >-
+  Unity iOS post process for forcing Pods to have Bitcode property YES/NO. You
+  can control bitcode status for all pods from single place. Highly usable with
+  CI.
+repoUrl: 'https://github.com/IvanMurzak/Unity-iOS-Pods-Bitcode'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - utilities
+hunter: IvanMurzak
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'master:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1670096441848


### PR DESCRIPTION
This pull request adds a new package definition for `com.github.ivanmurzak.ios.pods.bitcode`, which provides a Unity iOS post-processing utility to manage the Bitcode property for all CocoaPods in a project from a single location, supporting CI workflows.

New package addition:

* Added `data/packages/com.github.ivanmurzak.ios.pods.bitcode.yml` to register the iOS Pods Bitcode utility, including metadata such as name, description, repo URL, license, topics, and other configuration fields.