### PR TITLE
chore(data): new package com.revenuecat.purchases-unity

### DIFF
--- a/data/packages/com.revenuecat.purchases-unity.yml
+++ b/data/packages/com.revenuecat.purchases-unity.yml
@@ -1,0 +1,19 @@
+name: com.revenuecat.purchases-unity
+displayName: RevenueCat SDK for Unity
+description: Unity in-app purchases and subscriptions made easy. Supports iOS and Android.
+repoUrl: 'https://github.com/RevenueCat/purchases-unity'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - mobile
+hunter: RevenueCat
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1672161443935


### PR DESCRIPTION
Adding RevenueCat Unity SDK `purchases-unity` to OpenUPM package registry. https://www.revenuecat.com/docs/unity