### PR TITLE
Fix repo name and package names

### DIFF
--- a/data/packages/com.siegeup.iconrenderer.yml
+++ b/data/packages/com.siegeup.iconrenderer.yml
@@ -1,7 +1,7 @@
-name: com.siegeup.icon-renderer
+name: com.siegeup.iconrenderer
 displayName: SiegeUp.IconRenderer
 description: Universal extendable icons renderer for items and objects in editor mode.
-repoUrl: 'https://github.com/SiegeUp/SiegeUp-IconRenderer'
+repoUrl: 'https://github.com/SiegeUp/SiegeUp.IconRenderer'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: Abuksigun SiegeUp


### PR DESCRIPTION
I'm making a bunch of packages for modding of my game. I want to make their names more conventional. The modding is not ready yet, so these package is not used by anyone. I think it's totally safe to rename it.

Thank you.