### PR TITLE
(chore) exclude "preview" tags following upgrade

### DIFF
--- a/data/packages/com.realitycollective.service-framework.yml
+++ b/data/packages/com.realitycollective.service-framework.yml
@@ -9,7 +9,12 @@ topics:
   - integration
   - frameworks
 hunter: FejZa
-minVersion: 1.0.0
+minVersion: 1.0.1
+gitTagPrefix: ''
+gitTagIgnore: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
 createdAt: 1646396986653

--- a/data/packages/com.realitycollective.service-framework.yml
+++ b/data/packages/com.realitycollective.service-framework.yml
@@ -9,12 +9,7 @@ topics:
   - integration
   - frameworks
 hunter: FejZa
-gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.1
+minVersion: 1.0.0
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
-readme: 'development:README.md'
-readme_zhCN: ''
-displayName_zhCN: ''
-description_zhCN: ''
+readme: 'main:README.md'
 createdAt: 1646396986653

--- a/data/packages/com.realitycollective.service-framework.yml
+++ b/data/packages/com.realitycollective.service-framework.yml
@@ -11,7 +11,7 @@ topics:
 hunter: FejZa
 minVersion: 1.0.1
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: 'preview'
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'main:README.md'
 readme_zhCN: ''

--- a/data/packages/com.realitycollective.utilities.yml
+++ b/data/packages/com.realitycollective.utilities.yml
@@ -9,7 +9,7 @@ topics:
 hunter: FejZa
 minVersion: 1.0.0
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: 'preview'
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'main:README.md'
 readme_zhCN: ''

--- a/data/packages/com.realitycollective.utilities.yml
+++ b/data/packages/com.realitycollective.utilities.yml
@@ -7,12 +7,7 @@ licenseName: MIT License
 topics:
   - utilities
 hunter: FejZa
-gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.1
+minVersion: 1.0.0
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
-readme: 'development:README.md'
-readme_zhCN: ''
-displayName_zhCN: ''
-description_zhCN: ''
+readme: 'main:README.md'
 createdAt: 1646396986653

--- a/data/packages/com.realitycollective.utilities.yml
+++ b/data/packages/com.realitycollective.utilities.yml
@@ -8,6 +8,11 @@ topics:
   - utilities
 hunter: FejZa
 minVersion: 1.0.0
+gitTagPrefix: ''
+gitTagIgnore: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
 createdAt: 1646396986653

--- a/data/packages/com.realitytoolkit.core.yml
+++ b/data/packages/com.realitytoolkit.core.yml
@@ -12,8 +12,8 @@ topics:
   - utilities
 hunter: FejZa
 gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.2
+gitTagIgnore: 'preview'
+minVersion: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'development:README.md'
 readme_zhCN: ''

--- a/data/packages/com.realitytoolkit.devtools.yml
+++ b/data/packages/com.realitytoolkit.devtools.yml
@@ -13,7 +13,7 @@ topics:
   - utilities
 hunter: realitycollective
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: 'preview'
 minVersion: ''
 image: ''
 readme: 'development:README.md'

--- a/data/packages/com.realitytoolkit.metaplatform.yml
+++ b/data/packages/com.realitytoolkit.metaplatform.yml
@@ -10,8 +10,8 @@ topics:
   - integration
 hunter: FejZa
 gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.2
+gitTagIgnore: 'preview'
+minVersion: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'development:README.md'
 readme_zhCN: ''

--- a/data/packages/com.realitytoolkit.pico.yml
+++ b/data/packages/com.realitytoolkit.pico.yml
@@ -10,8 +10,8 @@ topics:
   - integration
 hunter: FejZa
 gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.2
+gitTagIgnore: 'preview'
+minVersion: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveBanner_600x300.png'
 readme: 'development:README.md'
 readme_zhCN: ''

--- a/data/packages/com.realitytoolkit.spatial-persistence.asa.yml
+++ b/data/packages/com.realitytoolkit.spatial-persistence.asa.yml
@@ -11,10 +11,10 @@ topics:
   - integration
 hunter: FejZa
 gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.1
+gitTagIgnore: 'preview'
+minVersion: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveLogo_256.png'
-readme: 'rcdevelopment:README.md'
+readme: 'development:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''

--- a/data/packages/com.realitytoolkit.spatial-persistence.yml
+++ b/data/packages/com.realitytoolkit.spatial-persistence.yml
@@ -12,10 +12,10 @@ topics:
   - utilities
 hunter: FejZa
 gitTagPrefix: ''
-gitTagIgnore: '^0.{5,20}'
-minVersion: 1.0.0-preview.1
+gitTagIgnore: 'preview'
+minVersion: ''
 image: 'https://github.com/realitycollective/realitycollective.logo/raw/main/Branding/RealityCollectiveLogo_256.png'
-readme: 'rcdevelopment:README.md'
+readme: 'development:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''


### PR DESCRIPTION
Upgrading the package definition to exclude the older "preview" tags for the RealityCollective/Toolkit as Unity no longer recognises these as "preview"