### PR TITLE
fix(data): fix VRCFury License and add git tag prefix

### DIFF
--- a/data/packages/com.vrcfury.vrcfury.yml
+++ b/data/packages/com.vrcfury.vrcfury.yml
@@ -4,11 +4,11 @@ description: Non-Destructive Tools for VRChat Avatars
 repoUrl: 'https://github.com/VRCFury/VRCFury'
 parentRepoUrl: null
 licenseSpdxId: ''
-licenseName: 'CC BY-ND 4.0, CC BY-ND 4.0'
+licenseName: 'CC BY-ND 4.0, CC BY-NC 4.0'
 topics:
   - editor-enhancement
 hunter: TayouVR
-gitTagPrefix: ''
+gitTagPrefix: 'com.vrcfury.vrcfury/'
 gitTagIgnore: ''
 minVersion: ''
 image: ''


### PR DESCRIPTION
so far VRCFury didn't have any per package version tags in semver format to be used like this yet. 
This will be fixed in future releases, the necessary tags will be added.