### PR TITLE
fix(com.air.animator-layer-copy): license: GPL -> LGPL

### DIFF
--- a/data/packages/com.air.animator-layer-copy.yml
+++ b/data/packages/com.air.animator-layer-copy.yml
@@ -4,7 +4,7 @@ description: Utility to copy layers from one animator to another
 repoUrl: 'https://github.com/TheLastRar/AnimatorLayerCopy'
 parentRepoUrl: null
 licenseSpdxId: ''
-licenseName: GPL-3.0 License
+licenseName: LGPL-3.0 License
 topics:
   - asset-management
 hunter: TayouVR


### PR DESCRIPTION
the script wasn't licensed so far and we have just discussed which license would work best, GPL would probably be incompatible with proprietary unity, so LGPL it is.
They will provide a license file in the repo shortly