### PR TITLE
chore(data): new package com.negipoyoc.voiceer

### DIFF
--- a/data/packages/com.negipoyoc.voiceer.yml
+++ b/data/packages/com.negipoyoc.voiceer.yml
@@ -1,0 +1,21 @@
+name: com.negipoyoc.voiceer
+displayName: Voiceer
+description: A package to connect audio clips to Unity editor events.
+repoUrl: 'https://github.com/3ternal/Voiceer'
+parentRepoUrl: 'https://github.com/negipoyoc/Voiceer'
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - audio
+  - editor-enhancement
+  - utilities
+hunter: 3ternal
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'master:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1681617807693


### PR DESCRIPTION
Hi! I'm attempting to bring a package over to OpenUPM. My fork contains a fix that allows the package to work in Unity 2021 onwards. Please let me know if I need to make any changes to the folder hierarchy.