### PR TITLE
chore(data): new package nl.netherlands3d.gltfast

### DIFF
--- a/data/packages/nl.netherlands3d.gltfast.yml
+++ b/data/packages/nl.netherlands3d.gltfast.yml
@@ -1,0 +1,22 @@
+name: nl.netherlands3d.gltfast
+displayName: glTFast [Netherlands3D]
+description: >-
+  A fork of glTFast for Netherlands3D to be optimized for WebGL; glTFast is used to 
+  import and export glTF 3D files efficiently at runtime or in the Editor
+repoUrl: 'https://github.com/Netherlands3D/glTFast'
+parentRepoUrl: 'https://github.com/atteneder/glTFast'
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+topics:
+  - modeling
+  - utilities
+hunter: mvriel
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1683560002428


### PR DESCRIPTION
With Netherlands3D (https://github.com/Amsterdam/Netherlands3D) we want to separate our packages into their own organisation and repositories so that we can provide re-usable building blocks. This is the first, where we provide a fork of glTFast that will optimize for WebGL by limiting the shader's number of loaded variants.

I have done my best to reflect in the package name and description that this is a variant and thus a fork of the original