### PR TITLE
Rename nl.netherlands3d.gltfast to eu.netherlands3d.gltfast

### DIFF
--- a/data/packages/eu.netherlands3d.gltfast.yml
+++ b/data/packages/eu.netherlands3d.gltfast.yml
@@ -1,4 +1,4 @@
-name: nl.netherlands3d.gltfast
+name: eu.netherlands3d.gltfast
 displayName: glTFast [Netherlands3D]
 description: >-
   A fork of glTFast for Netherlands3D to be optimized for WebGL; glTFast is used to 


### PR DESCRIPTION
Due to circumstances, we had to change our domain to netherlands3d.eu to prevent confusion, we want to rename the package(name) in openupm as well.

At this moment we expect there aren't any users consuming this package, so I believe this should not be a problem.