### PR TITLE
Create games.monogum.bricksbucket.propertyrefs.yml

### DIFF
--- a/data/packages/games.monogum.bricksbucket.propertyrefs.yml
+++ b/data/packages/games.monogum.bricksbucket.propertyrefs.yml
@@ -1,0 +1,21 @@
+name: games.monogum.bricksbucket.propertyrefs
+displayName: Property Refs
+description: >-
+  PropertyRef allows you to create shortcuts to the values of a prefab and
+  modify them.
+repoUrl: 'https://github.com/javier-games/property-refs'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - gui
+hunter: javier-games
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1687393543187


### PR DESCRIPTION
PropertyRefs is a comprehensive tool for Unity, crafted to streamline your game development tasks. By creating references to the properties of the components, you can efficiently access and manipulate them from other scripts, centralizing meaningful properties of a game object, prefab, or a scene in one location. This is a significant advantage for game and level designers, offering an enhanced and seamless workflow.