### PR TITLE
Convert net.bobbo packages to use new monorepo

### DIFF
--- a/data/packages/net.bobbo.being-entity.yml
+++ b/data/packages/net.bobbo.being-entity.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.being-entity
 displayName: Being Entity
 description: Who needs actors?
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.being-entity'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.camera-audio-listener-fmod.yml
+++ b/data/packages/net.bobbo.camera-audio-listener-fmod.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.camera-audio-listener-fmod
 displayName: Camera Audio Listener FMOD
 description: 'Audio, for the Camera - with FMOD!'
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.camera-audio-listener-fmod'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.camera-audio-listener.yml
+++ b/data/packages/net.bobbo.camera-audio-listener.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.camera-audio-listener
 displayName: Camera Audio Listener
 description: 'Audio, for the Camera!'
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.camera-audio-listener'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.camera-manager.yml
+++ b/data/packages/net.bobbo.camera-manager.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.camera-manager
 displayName: Camera Manager
 description: Extensible camera management with Cinemachine
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.camera-manager'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.dev-console.camera-manager.yml
+++ b/data/packages/net.bobbo.dev-console.camera-manager.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.dev-console.camera-manager
 displayName: Camera Manager Console Commands
 description: Console Commands for the CameraManager
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.dev-console.camera-manager'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.dev-console.yml
+++ b/data/packages/net.bobbo.dev-console.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.dev-console
 displayName: Development Console
 description: An in-game developer console.
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.dev-console'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.editor.search-window.yml
+++ b/data/packages/net.bobbo.editor.search-window.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.editor.search-window
 displayName: Editor Search Window
 description: Re-usable search window functionality for the Unity Editor
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.editor.search-window'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.extensions.float.yml
+++ b/data/packages/net.bobbo.extensions.float.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.extensions.float
 displayName: Float Extensions
 description: Extension methods for C#'s float Type
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.extensions.float'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.extensions.vector3.yml
+++ b/data/packages/net.bobbo.extensions.vector3.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.extensions.vector3
 displayName: Vector3 Extensions
 description: Extension methods for Unity's Vector3 Type
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.extensions.vector3'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.fmod-reverb-manager.yml
+++ b/data/packages/net.bobbo.fmod-reverb-manager.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.fmod-reverb-manager
 displayName: FMOD Reverb Manager
 description: Allows for managing basic FMOD reverb settings
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.fmod-reverb-manager'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.global-knowledge.yml
+++ b/data/packages/net.bobbo.global-knowledge.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.global-knowledge
 displayName: Global Knowledge
 description: Globally available player knowledge. Talk about game state!
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.global-knowledge'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.json-data.yml
+++ b/data/packages/net.bobbo.json-data.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.json-data
 displayName: JSON Data
 description: A wrapper for working with JSON Data
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.json-data'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.multi-lock.yml
+++ b/data/packages/net.bobbo.multi-lock.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.multi-lock
 displayName: Multi-Lock
 description: 'A locking utlity, to make interactions easier.'
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.multi-lock'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.player-behaviour.first-person-interactor.yml
+++ b/data/packages/net.bobbo.player-behaviour.first-person-interactor.yml
@@ -2,7 +2,7 @@ name: net.bobbo.player-behaviour.first-person-interactor
 displayName: Player Behaviour 1st Person Interactor
 description: First person interaction functionality for the Bobbo-Net Player Controller
 repoUrl: >-
-  https://github.com/BOBBO-NET/net.bobbo.player-behaviour.first-person-interactor
+  https://github.com/BOBBO-NET/netengine4
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.player-behaviour.first-person-movement.yml
+++ b/data/packages/net.bobbo.player-behaviour.first-person-movement.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.player-behaviour.first-person-movement
 displayName: Player Behaviour 1st Person Movement
 description: First person movement functionality for the Bobbo-Net Player Controller
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.player-behaviour.first-person-movement'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.player-behaviour.gravity.yml
+++ b/data/packages/net.bobbo.player-behaviour.gravity.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.player-behaviour.gravity
 displayName: Player Behaviour Gravity
 description: Basic gravity functionality for the Bobbo-Net Player Controller
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.player-behaviour.gravity'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.player-behaviour.health.yml
+++ b/data/packages/net.bobbo.player-behaviour.health.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.player-behaviour.health
 displayName: Player Behaviour Health
 description: Basic health functionality for the Bobbo-Net Player Controller
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.player-behaviour.health'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.player-controller.yml
+++ b/data/packages/net.bobbo.player-controller.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.player-controller
 displayName: Player Controller
 description: An extensible Player Controller module
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.player-controller'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License

--- a/data/packages/net.bobbo.xnode.global-knowledge.yml
+++ b/data/packages/net.bobbo.xnode.global-knowledge.yml
@@ -1,7 +1,7 @@
 name: net.bobbo.xnode.global-knowledge
 displayName: Global Knowledge XNode
 description: 'Globally available player knowledge, exposed through XNode!'
-repoUrl: 'https://github.com/BOBBO-NET/net.bobbo.xnode.global-knowledge'
+repoUrl: 'https://github.com/BOBBO-NET/netengine4'
 parentRepoUrl: null
 licenseSpdxId: ''
 licenseName: BOBBO-NET Friendly MIT License


### PR DESCRIPTION
This PR revises multiple of my packages starting with net.bobbo.* to point to a new monorepo rather than individual repos.