### PR TITLE
Correct LICENSE of com.needle.shadergraph-markdown

### DIFF
--- a/data/packages/com.needle.shadergraph-markdown.yml
+++ b/data/packages/com.needle.shadergraph-markdown.yml
@@ -5,6 +5,8 @@ description: >-
   inspectors
 repoUrl: 'https://github.com/needle-tools/shadergraph-markdown'
 parentRepoUrl: null
+licenseSpdxId: null
+licenseName: Custom
 topics:
   - editor-enhancement
   - particles-and-effects

--- a/data/packages/com.needle.shadergraph-markdown.yml
+++ b/data/packages/com.needle.shadergraph-markdown.yml
@@ -5,8 +5,6 @@ description: >-
   inspectors
 repoUrl: 'https://github.com/needle-tools/shadergraph-markdown'
 parentRepoUrl: null
-licenseSpdxId: MIT
-licenseName: MIT License
 topics:
   - editor-enhancement
   - particles-and-effects


### PR DESCRIPTION
It actually has a custom license, listing it as MIT is misleading see:

https://openupm.com/packages/com.needle.shadergraph-markdown/
> License
Shader Graph Markdown is [available on the Asset Store](http://u3d.as/2was) for commercial use.
Other versions are only allowed to be used non-commercially and only if you're entitled to use Unity Personal (the same restrictions apply).