### PR TITLE
Change Name

### DIFF
--- a/data/packages/com.virgis.geometry3sharp.yml
+++ b/data/packages/com.virgis.geometry3sharp.yml
@@ -1,20 +1,20 @@
-name: com.virgis.geometry3sharp
-displayName: Geometry 3 Sharp
+name: com.virgis.geometry
+displayName: ViRGiS Geometry Package
 description: >-
-  C# library for 2D/3D geometric computation, mesh algorithms, and so on. Boost
-  license.
+  Unity library for 2D/3D geometric computation, mesh algorithms, and more.
 repoUrl: 'https://github.com/ViRGIS-Team/geometry3Sharp'
-parentRepoUrl: 'https://github.com/gradientspace/geometry3Sharp'
+parentRepoUrl: 'https://github.com/ViRGIS-Team/ViRGiS-Geometry'
 licenseSpdxId: BSL-1.0
 licenseName: Boost Software License 1.0
 topics:
-  - utilities
+  - 3d
+  - Geometry
 hunter: runette
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: 1.0.4
+minVersion: 3.0.0
 image: null
 readme: 'master:README.md'
 createdAt: 1604871013551
-displayName_zhCN: Geometry 3 Sharp
+displayName_zhCN: ViRGiS Geometry Package
 description_zhCN: 用于2D/3D几何计算，Mesh算法等的C#库。

--- a/data/packages/com.virgis.geometry3sharp.yml
+++ b/data/packages/com.virgis.geometry3sharp.yml
@@ -2,7 +2,7 @@ name: com.virgis.geometry
 displayName: ViRGiS Geometry Package
 description: >-
   Unity library for 2D/3D geometric computation, mesh algorithms, and more.
-repoUrl: 'https://github.com/ViRGIS-Team/geometry3Sharp'
+repoUrl: 'https://github.com/ViRGIS-Team/ViRGiS-Geometry'
 parentRepoUrl: 'https://github.com/ViRGIS-Team/ViRGiS-Geometry'
 licenseSpdxId: BSL-1.0
 licenseName: Boost Software License 1.0


### PR DESCRIPTION
Name change because the original repo is now out of date and archived and there are now different active forks. This active fork is specifically and only for Unity and has Unity specific additions