### PR TITLE
Change name of Geometry3sharp

### DIFF
--- a/data/packages/com.virgis.geometry
+++ b/data/packages/com.virgis.geometry
@@ -1,0 +1,20 @@
+name: com.virgis.geometry
+displayName: ViRGiS Geometry Package
+description:
+  - Unity library for 2D/3D geometric computation, mesh algorithms, and more.
+repoUrl: 'https://github.com/ViRGIS-Team/ViRGiS-Geometry'
+parentRepoUrl: 'https://github.com/ViRGIS-Team/ViRGiS-Geometry'
+licenseSpdxId: BSL-1.0
+licenseName: Boost Software License 1.0
+topics:
+  - 3d
+  - Geometry
+hunter: runette
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 3.0.0
+image: null
+readme: 'master:README.md'
+createdAt: 1604871013551
+displayName_zhCN: ViRGiS Geometry Package
+description_zhCN: 用于2D/3D几何计算，Mesh算法等的C#库。


### PR DESCRIPTION
The existing repository has been archived and there are multiple active forks. This fork is specific to Unity