### PR TITLE
Minor naming changes to Newtonsoft.JSON packages

### DIFF
--- a/data/packages/jillejr.newtonsoft.json-for-unity.converters.yml
+++ b/data/packages/jillejr.newtonsoft.json-for-unity.converters.yml
@@ -2,14 +2,15 @@ name: jillejr.newtonsoft.json-for-unity.converters
 displayName: Json.NET Converters of Unity types
 description: >-
   Converters of common Unity types for Newtonsoft.Json. Goes hand in hand with
-  jilleJr/Newtonsoft.Json-for-Unity
-repoUrl: 'https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters'
+  applejag/Newtonsoft.Json-for-Unity
+  (formerly known as jilleJr/Newtonsoft.Json-for-Unity)
+repoUrl: 'https://github.com/applejag/Newtonsoft.Json-for-Unity.Converters'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
   - utilities
-hunter: jilleJr
+hunter: applejag
 gitTagPrefix: ''
 gitTagIgnore: ''
 image: null

--- a/data/packages/jillejr.newtonsoft.json-for-unity.yml
+++ b/data/packages/jillejr.newtonsoft.json-for-unity.yml
@@ -1,7 +1,9 @@
 name: jillejr.newtonsoft.json-for-unity
 displayName: Json.NET 12.0.3 for Unity
-description: Newtonsoft.Json (Json.NET) 12.0.3 for Unity via Unity Package Manager
-repoUrl: 'https://github.com/jilleJr/Newtonsoft.Json-for-Unity'
+description: >-
+  Newtonsoft.Json (Json.NET) 12.0.3 for Unity via Unity Package Manager
+  (Deprecated in favor of com.unity.nuget.newtonsoft-json@3.0)
+repoUrl: 'https://github.com/applejag/Newtonsoft.Json-for-Unity'
 parentRepoUrl: 'https://github.com/JamesNK/Newtonsoft.Json'
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
Hello!

I recently changed my GitHub username from jilleJr to applejag.

I will not be renaming the package names. They'll have to stay with the old names. So I'm only updating the GH repo references.

Also adding a "deprecated" note to the Json.NET package description. Is there a way to mark an entire package as deprecated?
