### PR TITLE
Reclaim ownership of EDM4U

### DIFF
--- a/data/packages/com.google.external-dependency-manager.yml
+++ b/data/packages/com.google.external-dependency-manager.yml
@@ -5,13 +5,15 @@ description: >-
   that requires Android specific libraries (e.g. AARs), iOS CocoaPods, version
   management of transitive dependencies, and/or management of Unity Package
   Manager registries.
-repoUrl: 'https://github.com/xinatcg/GoogleExternalDependencyManager'
+repoUrl: 'https://github.com/googlesamples/unity-jar-resolver'
 parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 topics:
   - utilities
-hunter: xinatcg
+  - editor-enhancement
+  - package-management
+hunter: f1yingbanana
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''


### PR DESCRIPTION
We have integrated official support for OpenUPM as part of our release process of External Dependency Manager for Unity (EDM4U), and thus we would like to now taking ownership of this package.