### PR TITLE
Create com.srichakradhar.unity-skip-splash-screen.yml

### DIFF
--- a/data/packages/com.srichakradhar.unity-skip-splash-screen.yml
+++ b/data/packages/com.srichakradhar.unity-skip-splash-screen.yml
@@ -1,0 +1,19 @@
+name: com.srichakradhar.unity-skip-splash-screen
+displayName: "â­\x90 Unity Skip Splash Screen â­\x90"
+description: A plugin to skip the Unity logo splash.
+repoUrl: https://github.com/srichakradhar/Unity-skip-splash-screen
+parentRepoUrl: https://github.com/RimuruDev/UnitySkipSplashScreen
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - 2d
+  - debugging-and-logging
+  - gui
+  - testing
+hunter: srichakradhar
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1709074032690


### PR DESCRIPTION
⭐ Unity Skip Splash Screen ⭐ - v1.0.1 Latest

This package allows you to quickly and easily remove the Unity splash screen when starting your application. Suitable for developers who want to jump straight to the content of their application without displaying Unity's initial Splash Screen.