### PR TITLE
Create com.google.ads.mobile.yml

### DIFF
--- a/data/packages/com.google.ads.mobile.yml
+++ b/data/packages/com.google.ads.mobile.yml
@@ -1,0 +1,22 @@
+name: com.google.ads.mobile
+displayName: Google Mobile Ads for Unity
+description: >-
+  The Google Mobile Ads package allows you to easily monetize your Unity apps
+  for iOS and Android using Google's native iOS and Android Mobile SDKs via a
+  unified C# API in Unity.
+repoUrl: https://github.com/googleads/googleads-mobile-unity
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: >-
+  https://lh3.googleusercontent.com/D71NOtwLFHvG8WfOO2fmSUTmbhT6ezmC0--7Si2A1BDjTSVcp6fJgAa4H-aVz-sZ2a7tcoXc7f_HBGq27lctq7mrqaOJD7tcfR_lOQ=w770-h734-p-nu-pa
+topics:
+  - mobile
+  - services
+  - integration
+hunter: googleads
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1711671887312


### PR DESCRIPTION
Google AdMob makes it easy for developers to earn money from their mobile apps with high-quality ads. This package enables Unity developers to easily serve Google Mobile Ads in Android and iOS apps without having to write Java or Objective-C code. See https://developers.google.com/unity/packages