### PR TITLE
Rename deprecated plugins

### DIFF
--- a/data/packages/com.uurha.betterdatastructures.yml
+++ b/data/packages/com.uurha.betterdatastructures.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterdatastructures
-displayName: Better Data Structures
+displayName: [Deprecated] Better Data Structures
 description: Collection of useful data structures for Unity
 repoUrl: 'https://github.com/techno-dwarf-works/better-data-structures'
 parentRepoUrl: null

--- a/data/packages/com.uurha.betterdatastructures.yml
+++ b/data/packages/com.uurha.betterdatastructures.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterdatastructures
-displayName: [Deprecated] Better Data Structures
+displayName: (Deprecated) Better Data Structures
 description: Collection of useful data structures for Unity
 repoUrl: 'https://github.com/techno-dwarf-works/better-data-structures'
 parentRepoUrl: null

--- a/data/packages/com.uurha.bettereditortools.yml
+++ b/data/packages/com.uurha.bettereditortools.yml
@@ -1,5 +1,5 @@
 name: com.uurha.bettereditortools
-displayName: Better Editor Tools
+displayName: [Deprecated] Better Editor Tools
 description: Collection of useful tools for Unity Editor
 repoUrl: 'https://github.com/techno-dwarf-works/better-editor-tools'
 parentRepoUrl: null

--- a/data/packages/com.uurha.bettereditortools.yml
+++ b/data/packages/com.uurha.bettereditortools.yml
@@ -1,5 +1,5 @@
 name: com.uurha.bettereditortools
-displayName: [Deprecated] Better Editor Tools
+displayName: (Deprecated) Better Editor Tools
 description: Collection of useful tools for Unity Editor
 repoUrl: 'https://github.com/techno-dwarf-works/better-editor-tools'
 parentRepoUrl: null

--- a/data/packages/com.uurha.betterextensions.yml
+++ b/data/packages/com.uurha.betterextensions.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterextensions
-displayName: [Deprecated] Better Extensions
+displayName: (Deprecated) Better Extensions
 description: >-
   Unity extensions, serialize extension, async extension, string extension and
   UI extensions

--- a/data/packages/com.uurha.betterextensions.yml
+++ b/data/packages/com.uurha.betterextensions.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterextensions
-displayName: Better Extensions
+displayName: [Deprecated] Better Extensions
 description: >-
   Unity extensions, serialize extension, async extension, string extension and
   UI extensions

--- a/data/packages/com.uurha.betterphotoneventbus.yml
+++ b/data/packages/com.uurha.betterphotoneventbus.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterphotoneventbus
-displayName: Photon Event Bus
+displayName: (Deprecated) Photon Event Bus
 description: Extension for Photon Networking RaiseEvent system
 repoUrl: 'https://github.com/techno-dwarf-works/photon-event-bus'
 parentRepoUrl: null

--- a/data/packages/com.uurha.betterruntimeconsole.yml
+++ b/data/packages/com.uurha.betterruntimeconsole.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterruntimeconsole
-displayName: Runtime Console
+displayName: (Deprecated) Runtime Console
 description: 'Runtime console, supports any unity logs from any thread'
 repoUrl: 'https://github.com/techno-dwarf-works/better-runtime-console'
 parentRepoUrl: null

--- a/data/packages/com.uurha.buildnotification.yml
+++ b/data/packages/com.uurha.buildnotification.yml
@@ -1,5 +1,5 @@
 name: com.uurha.buildnotification
-displayName: Build Notification
+displayName: (Deprecated) Build Notification
 description: Build Notification tool allows developers to receive notificaiton about build completion
 repoUrl: 'https://github.com/techno-dwarf-works/build-notification'
 parentRepoUrl: null


### PR DESCRIPTION
Plugins deprecated, but to keep old versions of dependencies intact I want to keep them with updated name 