### PR TITLE
Create com.kagekirin.unitycsharpier.yml

### DIFF
--- a/data/packages/com.kagekirin.unitycsharpier.yml
+++ b/data/packages/com.kagekirin.unitycsharpier.yml
@@ -1,0 +1,16 @@
+name: com.kagekirin.unitycsharpier
+displayName: CSharpier for Unity Editor
+description: Unity Editor extension to run CSharpier before recompiling C# source files
+repoUrl: https://github.com/KageKirin/UnityCSharpier
+parentRepoUrl: null
+licenseSpdxId: MPL-2.0
+licenseName: Mozilla Public License 2.0
+image: ''
+topics:
+  - editor-enhancement
+hunter: kagekirin
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 1.1.1
+readme: main:README.md
+createdAt: 1713403117081


### PR DESCRIPTION
PR created from submitting the package registration form.

UnityCSharpier extends the Editor to run CSharpier (`dotnet csharpier`) as C# formatting tool over all _modified_ source files, every time they are reloaded.

Note: The plugin requires installing CSharpier (`dotnet tool install -g csharpier`) beforehand.