### PR TITLE
Create com.kagekirin.unitygcprefresh.yml

### DIFF
--- a/data/packages/com.kagekirin.unitygcprefresh.yml
+++ b/data/packages/com.kagekirin.unitygcprefresh.yml
@@ -1,0 +1,19 @@
+name: com.kagekirin.unitygcprefresh
+displayName: GCPRefresh
+description: Unity Editor extension to refresh the GCP auth token in .upmconfig.toml
+repoUrl: https://github.com/KageKirin/UnityGCPRefresh
+parentRepoUrl: null
+licenseSpdxId: MPL-2.0
+licenseName: Mozilla Public License 2.0
+image: >-
+  https://github.com/KageKirin/UnityGCPRefresh/raw/main/Documentation~/unitygcprefresh.png
+topics:
+  - editor-enhancement
+  - package-management
+  - utilities
+hunter: KageKirin
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.0.5
+readme: main:README.md
+createdAt: 1713699678563


### PR DESCRIPTION
UnityGCPRefresh is a small helper tool to keep a connection to a GCP-hosted UPM registry alive while using Unity.