### PR TITLE
Create com.segur.platform-watcher.yml

### DIFF
--- a/data/packages/com.segur.platform-watcher.yml
+++ b/data/packages/com.segur.platform-watcher.yml
@@ -1,0 +1,16 @@
+name: com.segur.platform-watcher
+displayName: PlatformWatcher
+description: This tool displays an error if the Unity platform is not the specified one.
+repoUrl: https://github.com/segurvita/PlatformWatcher
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - debugging-and-logging
+hunter: segurvita
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1715411961892


### PR DESCRIPTION
This tool displays an error if the Unity platform is not the specified one.