### PR TITLE
Package name and description changes for two com.audune packages

### DIFF
--- a/data/packages/com.audune.utils.inputsystem.yml
+++ b/data/packages/com.audune.utils.inputsystem.yml
@@ -1,6 +1,6 @@
 name: com.audune.utils.inputsystem
-displayName: Input System Utilities
-description: Input System utilities for Unity 2022 LTS or higher.
+displayName: Unity Input System Utilities
+description: Unity Input System utilities for Unity 2022 LTS or higher.
 repoUrl: 'https://github.com/audunegames/inputsystem-utils'
 parentRepoUrl: null
 licenseSpdxId: GPL-3.0

--- a/data/packages/com.audune.utils.unityeditor.yml
+++ b/data/packages/com.audune.utils.unityeditor.yml
@@ -1,6 +1,6 @@
 name: com.audune.utils.unityeditor
-displayName: UnityEditor Utilities
-description: UnityEditor utilities for Unity 2022.3 LTS or higher.
+displayName: Unity IMGUI Editor Utilities
+description: Unity IMGUI Editor utilities for Unity 2022.3 LTS or higher.
 repoUrl: https://github.com/audunegames/unityeditor-utils
 parentRepoUrl: null
 licenseSpdxId: GPL-3.0


### PR DESCRIPTION
I changed the names and descriptions of the packages `com.audune.utils.unityeditor` and `com.audune.utils.inputsystem` to better reflect their usage.