### PR TITLE
Update com.mygamedevtools.scene-loader metadata

### DIFF
--- a/data/packages/com.mygamedevtools.scene-loader.yml
+++ b/data/packages/com.mygamedevtools.scene-loader.yml
@@ -1,9 +1,7 @@
 name: com.mygamedevtools.scene-loader
-displayName: Scene Loader
+displayName: Advanced Scene Manager
 description: >-
-  A package that standardizes the scene loading process among many different
-  possibilities, including support for Coroutines, C# Tasks, UniTask and
-  Addressables.
+  Enhance your scene loading experience in Unity.
 repoUrl: 'https://github.com/mygamedevtools/scene-loader'
 parentRepoUrl: null
 licenseSpdxId: MIT


### PR DESCRIPTION
The `com.mygamedevtools.scene-loader` package has been renamed after the release of version `3.0.0`.