### PR TITLE
Create com.google.ads.mobile.mediation.imobile.yml

### DIFF
--- a/data/packages/com.google.ads.mobile.mediation.imobile.yml
+++ b/data/packages/com.google.ads.mobile.mediation.imobile.yml
@@ -1,0 +1,21 @@
+name: com.google.ads.mobile.mediation.imobile
+displayName: Google Mobile Ads i-mobile Mediation
+description: >-
+  The Google Mobile Ads mediation plugin for i-mobile package allows you to load
+  and display ads from i-mobile using mediation, covering waterfall integration.
+repoUrl: https://github.com/googleads/googleads-mobile-unity-mediation
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: >-
+  https://lh3.googleusercontent.com/D71NOtwLFHvG8WfOO2fmSUTmbhT6ezmC0--7Si2A1BDjTSVcp6fJgAa4H-aVz-sZ2a7tcoXc7f_HBGq27lctq7mrqaOJD7tcfR_lOQ=w770-h734-p-nu-pa
+topics:
+  - integration
+  - mobile
+  - services
+hunter: googleads
+gitTagPrefix: IMobile/
+gitTagIgnore: ''
+minVersion: ''
+readme: main:IMobile/README.md
+createdAt: 1724209067988


### PR DESCRIPTION
The Google Mobile Ads mediation plugin for i-mobile package allows you to load and display ads from i-mobile using mediation, covering waterfall integration.