### PR TITLE
Deprecate com.uurha plugins

### DIFF
--- a/data/packages/com.uurha.betterattributes.yml
+++ b/data/packages/com.uurha.betterattributes.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterattributes
-displayName: Better Attributes
+displayName: (Deprecated) Better Attributes
 description: >-
   Unity attributes, allows to serialize interfaces, draw handles for
   Vector3/Vector2/Quaternion/Bounds, create read only fields.

--- a/data/packages/com.uurha.betterscenemanagement.yml
+++ b/data/packages/com.uurha.betterscenemanagement.yml
@@ -1,5 +1,5 @@
 name: com.uurha.betterscenemanagement
-displayName: Better Scene Management
+displayName: (Deprecated) Better Scene Management
 description: Scene loader with ability to load and serialize SceneAssets
 repoUrl: 'https://github.com/techno-dwarf-works/better-scene-management-legacy'
 parentRepoUrl: null

--- a/data/packages/com.uurha.bettervalidation.yml
+++ b/data/packages/com.uurha.bettervalidation.yml
@@ -1,5 +1,5 @@
 name: com.uurha.bettervalidation
-displayName: Better Validation
+displayName: (Deprecated) Better Validation
 description: ' '
 repoUrl: 'https://github.com/techno-dwarf-works/better-validation-legacy'
 parentRepoUrl: null


### PR DESCRIPTION
Plugins deprecated, but to keep old versions of dependencies intact I want to keep them with updated name