### PR TITLE
Create com.google.ads.mobile.mediation.inmobi.yml

### DIFF
--- a/data/packages/com.google.ads.mobile.mediation.inmobi.yml
+++ b/data/packages/com.google.ads.mobile.mediation.inmobi.yml
@@ -1,0 +1,22 @@
+name: com.google.ads.mobile.mediation.inmobi
+displayName: Google Mobile Ads InMobi Mediation
+description: >-
+  The Google Mobile Ads mediation plugin for InMobi package allows you to load
+  and display ads from InMobi using mediation, covering waterfall and bidding
+  integrations.
+repoUrl: https://github.com/googleads/googleads-mobile-unity-mediation
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: >-
+  https://lh3.googleusercontent.com/D71NOtwLFHvG8WfOO2fmSUTmbhT6ezmC0--7Si2A1BDjTSVcp6fJgAa4H-aVz-sZ2a7tcoXc7f_HBGq27lctq7mrqaOJD7tcfR_lOQ=w770-h734-p-nu-pa
+topics:
+  - integration
+  - mobile
+  - services
+hunter: googleads
+gitTagPrefix: InMobi/
+gitTagIgnore: ''
+minVersion: ''
+readme: main:InMobi/README.md
+createdAt: 1724783399543


### PR DESCRIPTION
The Google Mobile Ads mediation plugin for InMobi package allows you to load and display ads from InMobi using mediation, covering waterfall and bidding integrations.