### PR TITLE
Update some packages' repository link after ownership transfer

### DIFF
--- a/data/packages/com.lazysquirrellabs.minmaxrangeattribute.yml
+++ b/data/packages/com.lazysquirrellabs.minmaxrangeattribute.yml
@@ -3,7 +3,7 @@ displayName: Min/max range attribute
 description: >-
   A bounded (i.e., with a minimum and maximum) range attribute for Unity's
   Vector2 and Vector2Int fields.
-repoUrl: https://github.com/matheusamazonas/min_max_range_attribute
+repoUrl: https://github.com/lazysquirrellabs/min_max_range_attribute
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License

--- a/data/packages/com.lazysquirrellabs.spheregenerator.yml
+++ b/data/packages/com.lazysquirrellabs.spheregenerator.yml
@@ -1,7 +1,7 @@
 name: com.lazysquirrellabs.spheregenerator
 displayName: Sphere Generator
 description: Generate sphere meshes procedurally.
-repoUrl: https://github.com/matheusamazonas/sphere_generator
+repoUrl: https://github.com/lazysquirrellabs/sphere_generator
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License

--- a/data/packages/com.lazysquirrellabs.terracedterraingenerator.yml
+++ b/data/packages/com.lazysquirrellabs.terracedterraingenerator.yml
@@ -1,7 +1,7 @@
 name: com.lazysquirrellabs.terracedterraingenerator
 displayName: Terraced Terrain Generator
 description: Generate terraced terrains procedurally.
-repoUrl: 'https://github.com/matheusamazonas/TTG'
+repoUrl: 'https://github.com/lazysquirrellabs/TTG'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
I transferred some of my repos to my company's organization. Even though the old links still work, they are misleading, so I replaced them.