### PR TITLE
Update Twitter link to new X.com URL in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://discord.gg/FnUgWEP">
     <img src="https://img.shields.io/discord/662675048884207616.svg" />
   </a>
-  <a href="https://twitter.com/openupmupdate">
+  <a href="https://x.com/openupmupdate">
     <img alt="X Follow" src="https://img.shields.io/twitter/follow/openupmupdate?style=social">
   </a>
 </p>


### PR DESCRIPTION
I've changed the Twitter link to point directly to X.com. This way, we can skip the extra step of being redirected from the old twitter.com address.