### PR TITLE
Update com.draconware-dev.span-extensions.net.unity.yml

### DIFF
--- a/data/packages/com.draconware-dev.span-extensions.net.unity.yml
+++ b/data/packages/com.draconware-dev.span-extensions.net.unity.yml
@@ -16,7 +16,7 @@ topics:
   - utilities
 hunter: laicasaane
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: '^v'
 minVersion: ''
 readme: upm:README.md
 createdAt: 1716210576681


### PR DESCRIPTION
Taken into account the reality that up until now upstream tags always contain character `v` at the start, this commit seeks an easy way to ignore them automatically.