### PR TITLE
Create games.javier.upm.propertyrefs.yml

### DIFF
--- a/data/packages/games.javier.upm.propertyrefs.yml
+++ b/data/packages/games.javier.upm.propertyrefs.yml
@@ -1,0 +1,20 @@
+name: games.javier.upm.propertyrefs
+displayName: Property Refs
+description: >-
+  PropertyRef allows you to create shortcuts to the values of a prefab and
+  modify them.
+repoUrl: https://github.com/javier-games/upm-propertyrefs
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: https://img.itch.zone/aW1nLzE4NDkxMTk3LnBuZw==/x150/4kEF8z.png
+topics:
+  - code-generation
+  - editor-enhancement
+  - utilities
+hunter: javier-games
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1730971497942


### PR DESCRIPTION
Open-source tool for Unity, designed to streamline property management across your game’s components. With PropertyRefs, you can create centralized references to key properties in a game object, prefab, or scene, enabling easy access and modification from other scripts. This feature is particularly useful for game and level designers, as it helps keep complex projects organized and reduces the time spent hunting down properties.