### PR TITLE
Create com.google.ads.mobile.mediation.line.yml

### DIFF
--- a/data/packages/com.google.ads.mobile.mediation.line.yml
+++ b/data/packages/com.google.ads.mobile.mediation.line.yml
@@ -1,0 +1,21 @@
+name: com.google.ads.mobile.mediation.line
+displayName: Google Mobile Ads Line Mediation
+description: >-
+  The Google Mobile Ads mediation plugin for Line package allows you to load and
+  display ads from Line using mediation, covering waterfall integrations.
+repoUrl: https://github.com/googleads/googleads-mobile-unity-mediation
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: >-
+  https://lh3.googleusercontent.com/D71NOtwLFHvG8WfOO2fmSUTmbhT6ezmC0--7Si2A1BDjTSVcp6fJgAa4H-aVz-sZ2a7tcoXc7f_HBGq27lctq7mrqaOJD7tcfR_lOQ=w770-h734-p-nu-pa
+topics:
+  - integration
+  - mobile
+  - services
+hunter: googleads
+gitTagPrefix: Line/
+gitTagIgnore: ''
+minVersion: ''
+readme: main:Line/packages/com.google.ads.mobile.mediation.line/README.md
+createdAt: 1732743837318


### PR DESCRIPTION
The Google Mobile Ads mediation plugin for Line package allows you to load and display ads from Line using mediation, covering waterfall integrations.