### PR TITLE
Update com.kekchpek.umvvm.yml

### DIFF
--- a/data/packages/com.kekchpek.umvvm.yml
+++ b/data/packages/com.kekchpek.umvvm.yml
@@ -10,7 +10,7 @@ topics:
   - utilities
 hunter: kekchpek
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: 'v[0-9]*\.[0-9]*\.[0-9]*-(raw|dev)'
 minVersion: ''
 readme: master:README.md
 createdAt: 1724253284770


### PR DESCRIPTION
Since develop and feature branches has tag postfix and can have unfinished or not tested changes, exclude their tags from openupm