### PR TITLE
chore(data): fix com.motphys.* gitTagPrefix

### DIFF
--- a/data/packages/com.motphys.core.yml
+++ b/data/packages/com.motphys.core.yml
@@ -9,7 +9,7 @@ image: https://www.motphys.com/img/logo.868c1b7b.svg
 topics:
   - physics
 hunter: Motphys
-gitTagPrefix: com.motphys.rigidbody
+gitTagPrefix: com.motphys.rigidbody/
 gitTagIgnore: ''
 minVersion: ''
 readme: main:MotphysRigidbodyUnitySdk-2021.3-URP/Packages/com.motphys.core/README.md

--- a/data/packages/com.motphys.debugdraw.core.yml
+++ b/data/packages/com.motphys.debugdraw.core.yml
@@ -10,7 +10,7 @@ topics:
   - debugging-and-logging
   - physics
 hunter: Motphys
-gitTagPrefix: com.motphys.rigidbody
+gitTagPrefix: com.motphys.rigidbody/
 gitTagIgnore: ''
 minVersion: ''
 readme: >-

--- a/data/packages/com.motphys.debugdraw.editor.yml
+++ b/data/packages/com.motphys.debugdraw.editor.yml
@@ -12,7 +12,7 @@ topics:
   - debugging-and-logging
   - physics
 hunter: Motphys
-gitTagPrefix: com.motphys.rigidbody
+gitTagPrefix: com.motphys.rigidbody/
 gitTagIgnore: ''
 minVersion: ''
 readme: >-

--- a/data/packages/com.motphys.rigidbody.native.standard.yml
+++ b/data/packages/com.motphys.rigidbody.native.standard.yml
@@ -9,7 +9,7 @@ image: https://www.motphys.com/img/logo.868c1b7b.svg
 topics:
   - physics
 hunter: Motphys
-gitTagPrefix: com.motphys.rigidbody.native
+gitTagPrefix: com.motphys.rigidbody.native/
 gitTagIgnore: ''
 minVersion: ''
 readme: >-

--- a/data/packages/com.motphys.rigidbody.rawapi.yml
+++ b/data/packages/com.motphys.rigidbody.rawapi.yml
@@ -9,7 +9,7 @@ image: https://www.motphys.com/img/logo.868c1b7b.svg
 topics:
   - physics
 hunter: Motphys
-gitTagPrefix: com.motphys.rigidbody
+gitTagPrefix: com.motphys.rigidbody/
 gitTagIgnore: ''
 minVersion: ''
 readme: >-


### PR DESCRIPTION
The 8 packages under the "motphys" repository are actually divided into two versions:    
* for the native packages (3 packages)
* for the non-native packages (5 packages)

So I still plan to use only two tag prefixes. Then I realized that the other 5 packages should also include a "/" to avoid incorrect matches.    
