### PR TITLE
Update com.pereviader.manualdi.async.unity3d.yml

### DIFF
--- a/data/packages/com.pereviader.manualdi.async.unity3d.yml
+++ b/data/packages/com.pereviader.manualdi.async.unity3d.yml
@@ -12,6 +12,6 @@ topics:
 hunter: PereViader
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: 2.0.0
+minVersion: 2.0.0-preview.1
 readme: main:README.md
 createdAt: 1745270928647


### PR DESCRIPTION
The repo has a tag for v2.0.0-preview.1 and it was previously filtering for 2.0.0

I believe it states it can't find any tag above the min version because 2.0.0-preview.1 is below 2.0.0

Updating the min to that preview version 