### PR TITLE
Update and rename com.pereviader.manualdi.unity3d.yml to com.pereviader.manualdi.sync.unity3d.yml

### DIFF
--- a/data/packages/com.pereviader.manualdi.sync.unity3d.yml
+++ b/data/packages/com.pereviader.manualdi.sync.unity3d.yml
@@ -1,5 +1,5 @@
-name: com.pereviader.manualdi.unity3d
-displayName: ManualDi
+name: com.pereviader.manualdi.sync.unity3d
+displayName: ManualDi.Sync
 description: Fast C# dependency injection library that uses no reflexion
 repoUrl: https://github.com/PereViader/ManualDi.Unity3d
 parentRepoUrl: https://github.com/PereViader/ManualDi
@@ -12,6 +12,6 @@ topics:
 hunter: PereViader
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: '2.0.0-preview.1'
 readme: main:README.md
 createdAt: 1734709718009


### PR DESCRIPTION
The package now has two variants Sync and Async. The old package is now renamed to Sync and starts being published on the min version 2.0.0-preview.1

Before merging, to review that this change will properly keep the old package versions alive while working with the new publishing format.
Thanks!