### PR TITLE
feat : add README sync time display to package detail page (#5177)

### DIFF
--- a/app/models/packageExtra.js
+++ b/app/models/packageExtra.js
@@ -32,6 +32,7 @@ const propKeys = {
   updatedTime: "updatedTime",
   version: "ver",
   monthlyDownloads: "dl30d",
+  readmeSyncTime: "readmeSyncTime", // NEW: Key for README sync time
 };
 
 /**
@@ -44,6 +45,26 @@ const getPropKeyForLang = function(propKey, lang) {
   if (!lang || lang == "en-US") return propKey;
   else if (lang == "zh-CN") return propKey + "_zhCN";
   else throw new Error("Not implemented yet");
+};
+
+/**
+ * Set README sync time for a package.
+ * @param {string} packageName - The name of the package.
+ * @param {number} syncTime - The sync time (timestamp) to set.
+ * @returns {Promise<void>} - A Promise that resolves when the sync time has been set.
+ */
+const setReadmeSyncTime = async function(packageName, syncTime) {
+  await setValue(packageName, propKeys.readmeSyncTime, syncTime.toString());
+};
+
+/**
+ * Get README sync time for a package.
+ * @param {string} packageName - The name of the package.
+ * @returns {Promise<number>} - A Promise that resolves to the sync time (timestamp).
+ */
+const getReadmeSyncTime = async function(packageName) {
+  const value = await getValue(packageName, propKeys.readmeSyncTime);
+  return parseInt(value) || 0;
 };
 
 const setInvalidTags = async function(packageName, tags) {
@@ -133,45 +154,6 @@ const getReadmeHtml = async function(packageName, lang) {
   const key = getPropKeyForLang(propKeys.readmeHtml, lang);
   const text = await getValue(packageName, key);
   return text;
-};
-
-/**
- * Get image query data for a package, return { imageUrl, width, height, fit }
- * @param {string} packageName
- */
-const getImageQueryForPackage = async function(packageName) {
-  // get the image url
-  const pkg = await loadPackage(packageName);
-  const imageUrl = pkg.image;
-  if (!imageUrl) return null;
-  const width = config.packageExtra.image.width;
-  const height = config.packageExtra.image.height;
-  const fit = pkg.imageFit == "contain" ? "contain" : "cover";
-  return { imageUrl, width, height, fit };
-};
-
-/**
- * Get image query data for a GitHub user, return { imageUrl, width, height, fit }
- * @param {string} username
- * @param {Number} size
- */
-const getImageQueryForGithubUser = async function(username, size) {
-  // get the image url
-  const imageUrl = `https://github.com/${username}.png?size=${size}`;
-  return { imageUrl, width: size, height: size, fit: "cover" };
-};
-
-/**
- * Get the cached image filename
- * @param {string} packageName
- */
-const getCachedImageFilename = async function(packageName) {
-  const imageQuery = await getImageQueryForPackage(packageName);
-  if (imageQuery) {
-    const imageData = await getImage(imageQuery);
-    if (imageData) return imageData.filename;
-  }
-  return null;
 };
 
 const setRepoPushedTime = async function(packageName, value) {
@@ -295,6 +277,7 @@ module.exports = {
   getUnityVersion,
   getUpdatedTime,
   getVersion,
+  getReadmeSyncTime, // NEW: Export method to get README sync time
   propKeys,
   setAggregatedExtraData,
   setInvalidTags,
@@ -312,4 +295,5 @@ module.exports = {
   setUnityVersion,
   setUpdatedTime,
   setVersion,
+  setReadmeSyncTime, // NEW: Export method to set README sync time
 };

--- a/app/models/packageExtra.js
+++ b/app/models/packageExtra.js
@@ -67,6 +67,45 @@ const getReadmeSyncTime = async function(packageName) {
   return parseInt(value) || 0;
 };
 
+/**
+ * Get image query data for a package, return { imageUrl, width, height, fit }
+ * @param {string} packageName
+ */
+const getImageQueryForPackage = async function(packageName) {
+  // get the image url
+  const pkg = await loadPackage(packageName);
+  const imageUrl = pkg.image;
+  if (!imageUrl) return null;
+  const width = config.packageExtra.image.width;
+  const height = config.packageExtra.image.height;
+  const fit = pkg.imageFit == "contain" ? "contain" : "cover";
+  return { imageUrl, width, height, fit };
+};
+
+/**
+ * Get image query data for a GitHub user, return { imageUrl, width, height, fit }
+ * @param {string} username
+ * @param {Number} size
+ */
+const getImageQueryForGithubUser = async function(username, size) {
+  // get the image url
+  const imageUrl = `https://github.com/${username}.png?size=${size}`;
+  return { imageUrl, width: size, height: size, fit: "cover" };
+};
+
+/**
+ * Get the cached image filename
+ * @param {string} packageName
+ */
+const getCachedImageFilename = async function(packageName) {
+  const imageQuery = await getImageQueryForPackage(packageName);
+  if (imageQuery) {
+    const imageData = await getImage(imageQuery);
+    if (imageData) return imageData.filename;
+  }
+  return null;
+};
+
 const setInvalidTags = async function(packageName, tags) {
   const jsonText = JSON.stringify(tags, null, 0);
   await setValue(packageName, propKeys.invalidTags, jsonText);

--- a/app/views/packagesView.js
+++ b/app/views/packagesView.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const asyncHandler = require('express-async-handler')
+const asyncHandler = require('express-async-handler');
 
 const router = express.Router();
 var semver = require("semver");
@@ -38,23 +38,38 @@ router.get("/recent", asyncHandler(async function (req, res) {
  */
 router.get("/:name", asyncHandler(async function (req, res) {
   const packageName = req.params.name;
+
   // Get releases sorted by semver
   let releases = await Release.fetchAll(packageName);
   releases = releases.map(x => pick(x, releaseFields));
   releases.sort((a, b) => semver.rcompare(a["version"], b["version"]));
+
   // Get invalid tags
   let invalidTags = await PackageExtra.getInvalidTags(packageName);
   invalidTags = invalidTags.map(x => x.tag);
+
   // Get readme
   const readmeHtml = await PackageExtra.getReadmeHtml(packageName);
   const readmeHtml_zhCN = await PackageExtra.getReadmeHtml(
     packageName,
     "zh-CN"
   );
+
   // Get package scopes
   const scopes = await PackageExtra.getScopes(packageName);
+
+  // Get README sync time
+  const readmeSyncTime = await PackageExtra.getReadmeSyncTime(packageName);
+
   // Return as JSON
-  let data = { releases, invalidTags, readmeHtml, scopes, readmeHtml_zhCN };
+  let data = { 
+    releases, 
+    invalidTags, 
+    readmeHtml, 
+    scopes, 
+    readmeHtml_zhCN, 
+    readmeSyncTime 
+  };
   res.json(data);
 }));
 


### PR DESCRIPTION
This update adds a new feature to the package detail page that displays the last README sync time. 
It helps users understand how recent the displayed README content is. 
This feature enhances transparency and improves user trust in the displayed information.

Closes #5177
