### PR TITLE
Update blocked-scopes.yml

### DIFF
--- a/data/blocked-scopes.yml
+++ b/data/blocked-scopes.yml
@@ -204,6 +204,7 @@ scopes:
 
 # The testing purpose packages
 - ^com.danij.testpackage
+- com.g00gle.googleads-mobile-unity
 
 # The packages that are deprecated by the author and the source repository may be still available
 # https://github.com/techno-dwarf-works/better-components


### PR DESCRIPTION
## Unpublish package request

#### What's the reason to unpublish the package entirely?
* no other packages in the OpenUPM Public Registry depend on it.
 * it had less than 50 downloads over it's lifetime.

#### What's the package name?
com.g00gle.googleads-mobile-unity

#### Have you removed the package meta file and added the package name to the blocked-scopes.yml? Yes