### PR TITLE
feat: add com.clokk.mdmcp-unity

### DIFF
--- a/data/packages/com.clokk.mdmcp-unity.yml
+++ b/data/packages/com.clokk.mdmcp-unity.yml
@@ -11,3 +11,5 @@ topics:
   - http
   - mcp
 category: editor
+
+# ci: retrigger


### PR DESCRIPTION
Add MDMCP Server for Unity to OpenUPM registry.\nRepo: https://github.com/clokk/mdmcp-unity\nVersion: v0.2.3