### PR TITLE
Add package configuration for Palapal Issue Console

### DIFF
--- a/data/packages/com.palapalco.issue-console.yml
+++ b/data/packages/com.palapalco.issue-console.yml
@@ -1,0 +1,20 @@
+name: com.palapalco.issue-console
+displayName: Palapal Issue Console
+description: >-
+  Lightweight Issue Console for capturing and resolving project-specific issues
+  inside the Unity Editor. Provides an API for other packages to report issues
+  and register auto-fix actions.
+repoUrl: https://github.com/Ario92/PalapalUnity
+parentRepoUrl: null
+licenseSpdxId: ''
+licenseName: MIT
+image: ''
+topics:
+  - debugging-and-logging
+  - editor-enhancement
+hunter: Ario92
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: Dev:Packages/IssueConsole/README.md
+createdAt: 1766303788380


### PR DESCRIPTION
This YAML file defines the package configuration for the Palapal Issue Console, including metadata such as name, description, repository URL, license, and topics.