### PR TITLE
Add C Sharp Dev Tools package metadata

### DIFF
--- a/data/packages/com.mrunbelievable.csharpdevtools.yml
+++ b/data/packages/com.mrunbelievable.csharpdevtools.yml
@@ -1,0 +1,18 @@
+name: com.mrunbelievable.csharpdevtools
+displayName: C Sharp Dev Tools
+description: >-
+  C Sharp Dev Tools is a small framework for defensive development with
+  conditionally compiled assertions and logging tools.
+repoUrl: https://github.com/MrUnbelievable92/C-Sharp-Dev-Tools
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - utilities
+hunter: laicasaane
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: master:README.md
+createdAt: 1769792898864


### PR DESCRIPTION
Added metadata for C Sharp Dev Tools package including name, display name, description, repository URL, license, and topics.