### PR TITLE
Configure Nino to ignore alpha/beta/rc tags

### DIFF
--- a/data/packages/com.jasonxudeveloper.nino.yml
+++ b/data/packages/com.jasonxudeveloper.nino.yml
@@ -13,7 +13,7 @@ topics:
   - utilities
 hunter: JasonXuDeveloper
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: '-(alpha|beta|rc)\.'
 minVersion: ''
 readme: main:README.md
 createdAt: 1731484055162


### PR DESCRIPTION
## Summary

- **Package**: `com.jasonxudeveloper.nino`
- Sets `gitTagIgnore: '-(alpha|beta|rc)\.'` so OpenUPM skips non-Unity-compatible pre-release tags
- Nino now publishes dual tags: `v4.0.0-beta.47` (for NuGet/GitHub) and `v4.0.0-preview.147` (for Unity/OpenUPM)
- Unity only accepts `preview`/`pre`/`exp` as pre-release identifiers, so beta/alpha/rc tags were causing OpenUPM publish failures since `4.0.0-preview.119`

## Context

OpenUPM has been failing to publish Nino since beta.19 because it picks up tags like `v4.0.0-beta.46` and derives version `4.0.0-beta.46`, which Unity rejects. The Nino release workflow now creates a second `preview`-based tag on the same commit for OpenUPM compatibility. This config change tells OpenUPM to ignore the beta/alpha/rc tags and only process preview + stable tags.