### PR TITLE
Add com.akiojin.unity-cli-bridge

### DIFF
--- a/data/packages/com.akiojin.unity-cli-bridge.yml
+++ b/data/packages/com.akiojin.unity-cli-bridge.yml
@@ -12,8 +12,6 @@ image: ''
 topics:
   - ai
   - editor-enhancement
-  - cli
-  - automation
 hunter: akiojin
 gitTagPrefix: v
 gitTagIgnore: ''


### PR DESCRIPTION
## Package Information

- **Name**: `com.akiojin.unity-cli-bridge`
- **Display Name**: Unity CLI Bridge
- **Repository**: https://github.com/akiojin/unity-cli
- **Package Path**: `UnityCliBridge/Packages/unity-cli-bridge`
- **License**: MIT

## Description

Unity Editor bridge package for [unity-cli](https://github.com/akiojin/unity-cli) automation (screenshots, video capture, scene analysis, input automation).

This is the successor to `com.akiojin.unity-mcp-server` (already listed on OpenUPM), reimplemented as a native Rust CLI with direct TCP communication.

## Checklist

- [x] Package name follows [Unity naming convention](https://docs.unity3d.com/Manual/cus-naming.html)
- [x] Repository is public
- [x] Package has a valid `package.json`
- [x] License is MIT