### PR TITLE
Add Framewerk packages (5 packages)

### DIFF
--- a/data/packages/com.dyskotron.framewerk.core.yml
+++ b/data/packages/com.dyskotron.framewerk.core.yml
@@ -6,10 +6,6 @@ repoUrl: 'https://github.com/dyskotron/Framewerk'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
-  - framework
-  - dependency-injection
-  - architecture
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: '2.0.0-preview.2'
@@ -17,4 +13,7 @@ image: ''
 imageFit: cover
 readme: 'feature/framewerk2.0:README.md'
 hunter: hex-clawd
-createdAt: 1771383438000
+topics:
+  - frameworks
+  - utilities
+createdAt: 1739843100000

--- a/data/packages/com.dyskotron.framewerk.editor.yml
+++ b/data/packages/com.dyskotron.framewerk.editor.yml
@@ -6,10 +6,6 @@ repoUrl: 'https://github.com/dyskotron/Framewerk'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
-  - framework
-  - editor
-  - tools
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: '2.0.0-preview.2'
@@ -17,4 +13,7 @@ image: ''
 imageFit: cover
 readme: 'feature/framewerk2.0:README.md'
 hunter: hex-clawd
-createdAt: 1771383438000
+topics:
+  - frameworks
+  - editor-enhancement
+createdAt: 1739843100000

--- a/data/packages/com.dyskotron.framewerk.screenfsm.yml
+++ b/data/packages/com.dyskotron.framewerk.screenfsm.yml
@@ -6,10 +6,6 @@ repoUrl: 'https://github.com/dyskotron/Framewerk'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
-  - framework
-  - state-machine
-  - architecture
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: '2.0.0-preview.2'
@@ -17,4 +13,7 @@ image: ''
 imageFit: cover
 readme: 'feature/framewerk2.0:README.md'
 hunter: hex-clawd
-createdAt: 1771383438000
+topics:
+  - frameworks
+  - ai
+createdAt: 1739843100000

--- a/data/packages/com.dyskotron.framewerk.ui.yml
+++ b/data/packages/com.dyskotron.framewerk.ui.yml
@@ -6,10 +6,6 @@ repoUrl: 'https://github.com/dyskotron/Framewerk'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
-  - framework
-  - ui
-  - mvcs
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: '2.0.0-preview.2'
@@ -17,4 +13,7 @@ image: ''
 imageFit: cover
 readme: 'feature/framewerk2.0:README.md'
 hunter: hex-clawd
-createdAt: 1771383438000
+topics:
+  - frameworks
+  - gui
+createdAt: 1739843100000

--- a/data/packages/com.dyskotron.framewerk.yml
+++ b/data/packages/com.dyskotron.framewerk.yml
@@ -6,10 +6,6 @@ repoUrl: 'https://github.com/dyskotron/Framewerk'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
-  - framework
-  - dependency-injection
-  - architecture
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: '2.0.0-preview.2'
@@ -17,4 +13,7 @@ image: ''
 imageFit: cover
 readme: 'feature/framewerk2.0:README.md'
 hunter: hex-clawd
-createdAt: 1771383438000
+topics:
+  - frameworks
+  - utilities
+createdAt: 1739843100000


### PR DESCRIPTION
## New Packages

Adding 5 packages from the Framewerk Unity MVCS framework:

| Package | Description |
|---------|-------------|
| `com.dyskotron.framewerk` | Meta-package (includes all) |
| `com.dyskotron.framewerk.core` | IoC, Signals, Commands, Promises |
| `com.dyskotron.framewerk.ui` | Views, Mediators, Popups, Lists |
| `com.dyskotron.framewerk.screenfsm` | Screen-based state machine |
| `com.dyskotron.framewerk.editor` | Editor tools, wizards |

**Repository:** https://github.com/dyskotron/Framewerk
**License:** MIT
**Current Version:** 2.0.0-preview.2

All packages are from the same monorepo, sharing version tags.