### PR TITLE
Fix library name and change repo url

### DIFF
--- a/data/packages/com.maellacour.eyap-library.yml
+++ b/data/packages/com.maellacour.eyap-library.yml
@@ -7,8 +7,6 @@ licenseName: Mozilla Public License 2.0
 licenseSpdxId: MPL-2.0
 topics:
 - utilities
-- library
-- random
 hunter: Eyap53
 gitTagPrefix: ''
 gitTagIgnore: ''


### PR DESCRIPTION
There was a confusion with the package name. Change it from eyaplibrary to eyap-library to avoid confusion. also change the owner url.