### PR TITLE
Rename com.better.core.yml to com.betterplugins.core.yml

### DIFF
--- a/data/packages/com.betterplugins.core.yml
+++ b/data/packages/com.betterplugins.core.yml
@@ -1,7 +1,7 @@
-name: com.better.core
+name: com.betterplugins.core
 displayName: Better Core
 description: Base package for Better Plugins
-repoUrl: https://github.com/better-plugins/better-core
+repoUrl: https://github.com/better-plugins/core
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
### Overview
This Pull Request implements the package renaming from com.better.core to com.betterplugins.core, as previously noted in issue #6328.

### Changes
Updated the package identifier in the OpenUPM registry configuration.
Adjusted repository metadata to reflect the new naming convention.