### PR TITLE
Create com.sputnicyoji.unity-frame-dump.yml

### DIFF
--- a/data/packages/com.sputnicyoji.unity-frame-dump.yml
+++ b/data/packages/com.sputnicyoji.unity-frame-dump.yml
@@ -1,0 +1,22 @@
+name: com.sputnicyoji.unity-frame-dump
+displayName: Frame Debugger Exporter
+description: Export Unity Frame Debugger data to structured JSON for AI-assisted rendering analysis. Supports remote Android devices via USB with signal-based data capture.
+repoUrl: https://github.com/sputnicyoji/unity-frame-dump
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+- frame-debugger
+- rendering
+- performance
+- profiling
+hunter: sputnicyoji
+gitTagPrefix: v
+gitTagIgnore: ''
+minVersion: '1.0.0'
+image: ''
+readme: main:README.md
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1742227200000


### PR DESCRIPTION
## New Package Submission

**Package**: `com.sputnicyoji.unity-frame-dump`
**Display Name**: Frame Debugger Exporter
**Repository**: https://github.com/sputnicyoji/unity-frame-dump
**License**: MIT
**Current Version**: v1.1.0

### Description

Export Unity Frame Debugger data to structured JSON for AI-assisted rendering analysis. Supports remote Android devices via USB with signal-based data capture, auto-detecting Local/Remote connection mode.

### Checklist
- [x] Open-source with MIT license
- [x] Valid `package.json` with semantic versioning
- [x] Git tags for versioning (v1.0.0, v1.1.0)
- [x] Unity 2021.3+ compatible
- [x] Functional package (tested on Unity 2022.3)