### PR TITLE
Add com.styly.styly-netsync.utility

### DIFF
--- a/data/packages/com.styly.styly-netsync.utility.yml
+++ b/data/packages/com.styly.styly-netsync.utility.yml
@@ -1,0 +1,18 @@
+name: com.styly.styly-netsync.utility
+displayName: STYLY NetSync Utility
+description: STYLY NetSync Utility
+repoUrl: https://github.com/styly-dev/STYLY-NetSync-Utility
+parentRepoUrl: null
+licenseName: Apache License 2.0
+licenseSpdxId: Apache-2.0
+image: ''
+topics:
+- ar-and-vr
+- frameworks
+- network
+- utilities
+hunter: styly-dev
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:STYLY-NetSync-Utility-Unity/README.md

--- a/data/packages/com.styly.styly-netsync.utility.yml
+++ b/data/packages/com.styly.styly-netsync.utility.yml
@@ -16,3 +16,4 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
 readme: main:STYLY-NetSync-Utility-Unity/README.md
+createdAt: 1775193738273


### PR DESCRIPTION
## Package information

- Package name: `com.styly.styly-netsync.utility`
- Repository: https://github.com/styly-dev/STYLY-NetSync-Utility
- License: Apache-2.0
- Hunter: styly-dev

Related package: `com.styly.styly-netsync` (already registered)