### PR TITLE
Add org.tikim.mockscene

### DIFF
--- a/data/packages/org.tikim.mockscene.yml
+++ b/data/packages/org.tikim.mockscene.yml
@@ -1,0 +1,15 @@
+name: org.tikim.mockscene
+displayName: Tikim MockScene
+description: >-
+  Scene-scoped mock scenario management tools for editor play mode validation.
+repoUrl: 'https://github.com/xhdtn8070/mock-scene'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - editor-enhancement
+  - testing
+  - utilities
+hunter: xhdtn8070
+readme: 'main:LocalPackages/org.tikim.mockscene/README.md'
+createdAt: 1776266369038


### PR DESCRIPTION
## Summary
- add metadata for `org.tikim.mockscene`
- register the package from `https://github.com/xhdtn8070/mock-scene`
- point the OpenUPM README view to the package README under `LocalPackages/org.tikim.mockscene`

## Package details
- Repository: https://github.com/xhdtn8070/mock-scene
- Package path: `/LocalPackages/org.tikim.mockscene`
- Latest release tag: `v1.0.0`
- License: `MIT`
- Unity version: `6000.0`

## Notes
- This repository contains a Unity project at the root and the UPM package under `LocalPackages/org.tikim.mockscene`.
- The package README and changelog are already public in the repository.
