### PR TITLE
Add ZLMediakit plugin configuration file

### DIFF
--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -5,7 +5,8 @@ repoUrl: https://github.com/XiaoJingSpace/ZLMediakitPlugin.git
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
-  - unity
+  - zlmediakit
+  - wvppro
   - webrtc
   - sip
   - streaming

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -1,0 +1,15 @@
+name: com.xiaojingspace.zlmediakit
+displayName: ZLMediakit Plugin
+description: Unity plugin for WVP PRO SIP port negotiation and ZLMediaKit WebRTC publishing.
+repoUrl: https://github.com/XiaoJingSpace/ZLMediakitPlugin.git
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - unity
+  - webrtc
+  - sip
+  - streaming
+  - gb28181
+minVersion: 1.0.0
+readme: upm:README.md
+hunter: XiaoJingSpace

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -13,3 +13,4 @@ topics:
 minVersion: 1.0.0
 readme: upm:README.md
 hunter: XiaoJingSpace
+createdAt: 2026-04-23

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -4,6 +4,7 @@ description: Unity plugin for WVP PRO SIP port negotiation and ZLMediaKit WebRTC
 repoUrl: https://github.com/XiaoJingSpace/ZLMediakitPlugin.git
 licenseSpdxId: MIT
 licenseName: MIT License
+topics: []
 minVersion: 1.0.0
 readme: upm:README.md
 hunter: XiaoJingSpace

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -5,9 +5,8 @@ repoUrl: https://github.com/XiaoJingSpace/ZLMediakitPlugin.git
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
-  - networking
-  - video
-  - utilities
+  - ar
+  - vr
 minVersion: 1.0.0
 readme: upm:README.md
 hunter: XiaoJingSpace

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -4,9 +4,6 @@ description: Unity plugin for WVP PRO SIP port negotiation and ZLMediaKit WebRTC
 repoUrl: https://github.com/XiaoJingSpace/ZLMediakitPlugin.git
 licenseSpdxId: MIT
 licenseName: MIT License
-topics:
-  - ar
-  - vr
 minVersion: 1.0.0
 readme: upm:README.md
 hunter: XiaoJingSpace

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -5,12 +5,9 @@ repoUrl: https://github.com/XiaoJingSpace/ZLMediakitPlugin.git
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
-  - zlmediakit
-  - wvppro
-  - webrtc
-  - sip
-  - streaming
-  - gb28181
+  - networking
+  - video
+  - utilities
 minVersion: 1.0.0
 readme: upm:README.md
 hunter: XiaoJingSpace

--- a/data/packages/com.xiaojingspace.zlmediakit.yml
+++ b/data/packages/com.xiaojingspace.zlmediakit.yml
@@ -13,4 +13,4 @@ topics:
 minVersion: 1.0.0
 readme: upm:README.md
 hunter: XiaoJingSpace
-createdAt: 2026-04-23
+createdAt: 1713830400000


### PR DESCRIPTION
ZLMediakitPlugin is a Unity plugin that bridges video streaming workflows between Unity applications, WVP PRO (a SIP/GB28181 server), and ZLMediaKit (a media server).

When the user triggers a “Start Task” action, the plugin handles the following:

SIP port negotiation – A SIPClient communicates with WVP PRO via SIP INVITE/SDP to request and obtain an available media port.

WebRTC streaming – After the port is ready, a ZLMediakitSender (extending WebRTCSender) exchanges HTTP offer/answer with ZLMediaKit and pushes a WebRTC stream using Unity’s camera (by index), RenderTexture, and/or AudioSource.

The plugin provides a central manager (ZLMediakitPluginManager) as the entry point for business logic, along with modular SIP, WebRTC, and configuration components. It is designed for real‑time streaming from Unity to ZLMediaKit via WVP PRO’s SIP negotiation, with support for custom extensions (authentication, TCP/TLS, custom headers).