### PR TITLE
chore(data): new package com.reify.unity

### DIFF
--- a/data/packages/com.reify.unity.yml
+++ b/data/packages/com.reify.unity.yml
@@ -1,0 +1,22 @@
+name: com.reify.unity
+displayName: Reify
+description: >-
+  Structured state for Unity, for LLMs that reason. 230+ MCP tools plus MCP
+  resources/prompts, with evidence-first design: structured JSON responses,
+  ambiguity rejection, Undo-backed writes, spatial anchor proofs, and ADR-backed
+  write receipts. Editor-side bridge for the Reify MCP server.
+repoUrl: https://github.com/mattebin/reify
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: ''
+topics:
+  - ai
+  - editor-enhancement
+  - integration
+hunter: mattebin
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.2.0
+readme: main:README.md
+createdAt: 1776902643267


### PR DESCRIPTION
Adds `com.reify.unity` — a Unity Editor MCP server for LLMs that need checkable evidence instead of screenshots.

- Repo: https://github.com/mattebin/reify
- Package folder: `src/Editor/`
- Initial version: `v0.2.0`
- License: Apache-2.0
- Unity: 2021.3+
- 230+ MCP tools, ADR-enforced write receipts, anchor-proven spatial claims.

The package is hosted in a monorepo. The UPM `package.json` lives at `src/Editor/package.json`; git tags are single-package unprefixed (`v0.2.0`).