### PR TITLE
Update image URL in com.dbrizov.naughtyattributes.yml

### DIFF
--- a/data/packages/com.dbrizov.naughtyattributes.yml
+++ b/data/packages/com.dbrizov.naughtyattributes.yml
@@ -10,6 +10,6 @@ topics:
 hunter: favoyang
 createdAt: 1576336399000
 image: >-
-  https://raw.githubusercontent.com/dbrizov/NaughtyAttributes/4ea46ce34ae5222bba03def2033326a5b53d47c5/Assets/NaughtyAttributes/Documentation~/ReorderableList_Inspector.gif
+  https://raw.githubusercontent.com/dbrizov/NaughtyAttributes/refs/heads/master/Assets/NaughtyAttributes/Documentation%7E/NaughtyAttributes_Cover_420x280.png
 displayName_zhCN: NaughtyAttributes
 description_zhCN: Unity的属性扩展


### PR DESCRIPTION
I updated the image for NaughtyAttributes. Here is a preview.

<img width="420" height="280" alt="NaughtyAttributes_Cover_420x280" src="https://github.com/user-attachments/assets/77b0a164-e7f5-4f26-a6e8-9e16c869abfb" />