### PR TITLE
Rename package from com.rebeat to jp.rebeat

### DIFF
--- a/data/packages/jp.rebeat.openapicodegen.yml
+++ b/data/packages/jp.rebeat.openapicodegen.yml
@@ -14,6 +14,6 @@ topics:
 hunter: HIROHIRO1224
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: '0.3.1'
 readme: release:README.md
 createdAt: 1746516551639

--- a/data/packages/jp.rebeat.openapicodegen.yml
+++ b/data/packages/jp.rebeat.openapicodegen.yml
@@ -1,4 +1,4 @@
-name: com.rebeat.openapicodegen
+name: jp.rebeat.openapicodegen
 displayName: OpenApiCodeGen
 description: >-
   This is a package to make a rest api client c-sharp file from swagger's json


### PR DESCRIPTION
This PR renames the package from com.rebeat.openapicodegen to jp.rebeat.openapicodegen.

The repository package.json has already been updated and tagged.
New package name: jp.rebeat.openapicodegen
New version/tag: v0.3.1

minVersion is set to 0.3.1 so OpenUPM ignores older tags that still use com.rebeat.openapicodegen.