### PR TITLE
Rename package and update minimum version in configuration

### DIFF
--- a/data/packages/jp.rebeat.openapicodegen.yml
+++ b/data/packages/jp.rebeat.openapicodegen.yml
@@ -14,6 +14,6 @@ topics:
 hunter: HIROHIRO1224
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: '0.3.1'
 readme: release:README.md
 createdAt: 1746516551639

--- a/data/packages/jp.rebeat.openapicodegen.yml
+++ b/data/packages/jp.rebeat.openapicodegen.yml
@@ -1,4 +1,4 @@
-name: com.rebeat.openapicodegen
+name: jp.rebeat.openapicodegen
 displayName: OpenApiCodeGen
 description: >-
   This is a package to make a rest api client c-sharp file from swagger's json

--- a/data/packages/jp.rhycol.openapicodegen.yml
+++ b/data/packages/jp.rhycol.openapicodegen.yml
@@ -1,4 +1,4 @@
-name: jp.rebeat.openapicodegen
+name: jp.rhycol.openapicodegen
 displayName: OpenApiCodeGen
 description: >-
   This is a package to make a rest api client c-sharp file from swagger's json
@@ -14,6 +14,6 @@ topics:
 hunter: HIROHIRO1224
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: '0.3.1'
+minVersion: '0.4.0'
 readme: release:README.md
 createdAt: 1746516551639


### PR DESCRIPTION
This PR renames the package from jp.rebeat.openapicodegen to jp.rhycol.openapicodegen.

The upstream package.json has already been updated, the version has been bumped, and the corresponding Git tag has been pushed.

Old name: jp.rebeat.openapicodegen
New name: jp.rhycol.openapicodegen
Tag: v0.4.0