### PR TITLE
[codex] update Vatsal backer expiry

### DIFF
--- a/data/backers.yml
+++ b/data/backers.yml
@@ -1,6 +1,7 @@
 items:
   - name: Vatsal Ambastha
     githubUser: adrenak
+    expires: 2026-06-30
   - name: Mike Wuetherick
     githubUser: gekidoslair
   - name: Andreas Atteneder


### PR DESCRIPTION
## Summary

- Set Vatsal Ambastha's backer expiry to 2026-06-30.
- Leave the separate sponsor tier record unchanged.

## Validation

- Inspected the staged diff for `data/backers.yml` before commit.
- No automated tests were run; this is a one-line YAML data update.