### PR TITLE
Add AnkleBreaker Unity MCP plugin metadata

### DIFF
--- a/data/packages/com.anklebreaker.unity-mcp.yml
+++ b/data/packages/com.anklebreaker.unity-mcp.yml
@@ -4,8 +4,8 @@ description: "MCP (Model Context Protocol) bridge plugin for Unity Editor. Enabl
 repoUrl: https://github.com/AnkleBreaker-Studio/unity-mcp-plugin
 trackingMode: git
 parentRepoUrl: null
-licenseSpdxId: ''
-licenseName: MIT
+licenseSpdxId: MIT
+licenseName: MIT License
 image: >-
   https://raw.githubusercontent.com/AnkleBreaker-Studio/unity-mcp-plugin/refs/heads/main/icon.png
 topics:

--- a/data/packages/com.anklebreaker.unity-mcp.yml
+++ b/data/packages/com.anklebreaker.unity-mcp.yml
@@ -1,0 +1,18 @@
+name: com.anklebreaker.unity-mcp
+displayName: AnkleBreaker Unity MCP
+description: "MCP (Model Context Protocol) bridge plugin for Unity Editor. Enables AI assistants like Claude to control Unity Editor via a local HTTP API â\x80\x94 manage scenes, GameObjects, components, assets, builds, and more."
+repoUrl: https://github.com/AnkleBreaker-Studio/unity-mcp-plugin
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: ''
+licenseName: MIT
+image: >-
+  https://raw.githubusercontent.com/AnkleBreaker-Studio/unity-mcp-plugin/refs/heads/main/icon.png
+topics:
+  - ai
+hunter: ilterbilguven
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1778143986634


### PR DESCRIPTION
Added metadata for AnkleBreaker Unity MCP plugin including name, description, repository URL, license, and topics.