### PR TITLE
[codex] Normalize SPDX license names

### DIFF
--- a/data/packages/co.balancy.nutaku.yml
+++ b/data/packages/co.balancy.nutaku.yml
@@ -5,7 +5,7 @@ repoUrl: https://github.com/balancy-liveops/plugin_cpp_unity_nutaku
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: 'MIT'
-licenseName: MIT
+licenseName: MIT License
 image: ''
 topics:
   - integration

--- a/data/packages/co.balancy.unity-addressables.yml
+++ b/data/packages/co.balancy.unity-addressables.yml
@@ -5,7 +5,7 @@ repoUrl: https://github.com/balancy-liveops/plugin_cpp_unity_addressables
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: 'MIT'
-licenseName: MIT
+licenseName: MIT License
 image: ''
 topics:
   - asset-management

--- a/data/packages/com.audune.utils.random.yml
+++ b/data/packages/com.audune.utils.random.yml
@@ -5,7 +5,7 @@ repoUrl: https://github.com/audunegames/random-numbers
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: LGPL-3.0
-licenseName: GNU Lesser General Public License v3.0
+licenseName: GNU Lesser General Public License v3.0 only
 image: ''
 topics:
   - utilities

--- a/data/packages/com.dandydino.elements.yml
+++ b/data/packages/com.dandydino.elements.yml
@@ -7,7 +7,7 @@ repoUrl: https://github.com/AlbertoVosgerau/DDElements
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: WTFPL
-licenseName: WTFPL
+licenseName: Do What The F*ck You Want To Public License
 image: ''
 topics:
   - editor-enhancement

--- a/data/packages/com.endelways.screenmanager.yml
+++ b/data/packages/com.endelways.screenmanager.yml
@@ -5,7 +5,7 @@ repoUrl: https://github.com/Endelways/ScreenManager
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: GPL-3.0
-licenseName: GNU General Public License v3.0
+licenseName: GNU General Public License v3.0 only
 image: ''
 topics:
   - frameworks

--- a/data/packages/com.jerbo.inspector.yml
+++ b/data/packages/com.jerbo.inspector.yml
@@ -5,7 +5,7 @@ repoUrl: https://github.com/tomjerbo/Inspector
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: 'MIT'
-licenseName: MIT
+licenseName: MIT License
 image: ''
 topics:
   - utilities

--- a/data/packages/com.nixstudio.nixsdk.yml
+++ b/data/packages/com.nixstudio.nixsdk.yml
@@ -5,7 +5,7 @@ repoUrl: https://github.com/tien0702/com.nixstudio.nixsdk
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: GPL-3.0
-licenseName: GNU General Public License v3.0
+licenseName: GNU General Public License v3.0 only
 image: ''
 topics:
   - mobile

--- a/data/packages/com.palapalco.issue_console.yml
+++ b/data/packages/com.palapalco.issue_console.yml
@@ -8,7 +8,7 @@ repoUrl: https://github.com/Ario92/PalapalUnity
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
-licenseName: MIT
+licenseName: MIT License
 image: ''
 topics:
   - debugging-and-logging

--- a/data/packages/com.techdigga.easy-ump.yml
+++ b/data/packages/com.techdigga.easy-ump.yml
@@ -7,7 +7,7 @@ repoUrl: https://github.com/techdigga/easy-ump
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
-licenseName: MIT
+licenseName: MIT License
 image: https://raw.githubusercontent.com/techdigga/easy-ump/main/Editor/Resources/easy-ump-icon.png
 topics:
   - data-management


### PR DESCRIPTION
## Summary

- update 9 published package manifests so `licenseName` exactly matches the SPDX full name for their `licenseSpdxId`
- keep `data/packages-norelease` unchanged per the published-data scope

## Validation

- `OPENUPM_NEXT_PATH=<openupm-next-validator-worktree> npm test`
- the matching validator branch was also checked with `OPENUPM_DATA_PATH=<openupm-data-worktree>/data npm run test --workspace packages/@openupm/local-data`, `npm run lint`, and `npm run build --workspace packages/@openupm/local-data`