### PR TITLE
[codex] Improve agent workflow notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@ Tests use Node's built-in `node:test` module and `node:assert/strict`. Add focus
 Use `chore(data): ...` for package CRUD and metadata-only changes, for example `chore(data): add com.vendor.package` or `chore(data): delist com.vendor.package`. Because package submission PRs are often auto-merged, history may also contain generated subjects such as `Create com.vendor.package.yml` or `Rename package from old.id to new.id`; do not treat those as the preferred manual style.
 
 Pull requests should describe the package or metadata change, link related issues when available, and include validation results. For package additions or renames, mention the package id, repository URL, tracking mode, license, and any localization fields touched. Screenshots are only useful when changing images or display metadata.
+Do not include machine-local absolute paths in PR titles, bodies, comments, or
+issues. Replace local worktree paths with placeholders such as
+`<openupm-next-worktree>` or use repo-relative paths.
 Before opening a PR from a worktree, check `git log --oneline origin/master..HEAD`
 and the changed-file list. The canonical `master` branch may contain local
 operator commits, so feature branches should be rebased onto `origin/master`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ This repository stores curated OpenUPM package data and the validation wrapper u
 - `npm run test:data`: validate `data/` with the built validator from `openupm-next`.
 
 The data test expects a built `openupm-next` checkout next to this repository at `../openupm-next`, or set `OPENUPM_NEXT_PATH=/path/to/openupm-next`. Build `openupm-next` before running validation locally.
+When validating against an `openupm-next` feature worktree, set
+`OPENUPM_NEXT_PATH` to that worktree and ensure its
+`packages/@openupm/local-data/build/cli/validate-data.js` has been rebuilt.
 
 When searching, remember `rg` skips hidden paths by default. Use `rg --hidden ...` when hidden project directories need to be included.
 
@@ -36,6 +39,10 @@ Tests use Node's built-in `node:test` module and `node:assert/strict`. Add focus
 Use `chore(data): ...` for package CRUD and metadata-only changes, for example `chore(data): add com.vendor.package` or `chore(data): delist com.vendor.package`. Because package submission PRs are often auto-merged, history may also contain generated subjects such as `Create com.vendor.package.yml` or `Rename package from old.id to new.id`; do not treat those as the preferred manual style.
 
 Pull requests should describe the package or metadata change, link related issues when available, and include validation results. For package additions or renames, mention the package id, repository URL, tracking mode, license, and any localization fields touched. Screenshots are only useful when changing images or display metadata.
+Before opening a PR from a worktree, check `git log --oneline origin/master..HEAD`
+and the changed-file list. The canonical `master` branch may contain local
+operator commits, so feature branches should be rebased onto `origin/master`
+when those commits are unrelated to the data change.
 
 Before creating GitHub issues or opening PRs that manipulate package data, read `.github/ISSUE_TEMPLATE/`. The templates document expected workflows for package replacement, unpublish requests, bug reports, feature requests, and abuse reports.
 


### PR DESCRIPTION
## Summary

- document validating data against an `openupm-next` feature worktree through `OPENUPM_NEXT_PATH`
- add a pre-PR check for `origin/master..HEAD` and changed files so local operator commits do not leak into data PRs
- document that PR and issue text must use placeholders or repo-relative paths instead of machine-local absolute paths

## Validation

- Not run; `AGENTS.md` guidance-only change with `[skip ci]` commits.