### PR TITLE
add com.gamebooom.unity.mcp

### DIFF
--- a/data/packages/com.gamebooom.unity.mcp.yml
+++ b/data/packages/com.gamebooom.unity.mcp.yml
@@ -1,0 +1,24 @@
+name: com.gamebooom.unity.mcp
+displayName: Funplay MCP for Unity
+description: >-
+  MIT-licensed MCP server for Unity Editor with execute_code, prompts/resources,
+  input simulation, screenshots, and play mode automation. Connects AI clients
+  (Claude Code, Cursor, Codex, VS Code) directly to the Unity Editor over a
+  local HTTP MCP server.
+repoUrl: https://github.com/FunplayAI/funplay-unity-mcp
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: https://raw.githubusercontent.com/FunplayAI/funplay-unity-mcp/main/Documentation%7E/Text+Logo.png
+topics:
+  - ai
+  - code-generation
+  - editor-enhancement
+  - utility
+hunter: Winlifes
+gitTagPrefix: v
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1778654760705

--- a/data/packages/com.gamebooom.unity.mcp.yml
+++ b/data/packages/com.gamebooom.unity.mcp.yml
@@ -15,7 +15,7 @@ topics:
   - ai
   - code-generation
   - editor-enhancement
-  - utility
+  - utilities
 hunter: Winlifes
 gitTagPrefix: v
 gitTagIgnore: ''


### PR DESCRIPTION
## Package

- **Name**: `com.gamebooom.unity.mcp`
- **Display name**: Funplay MCP for Unity
- **Repo**: https://github.com/FunplayAI/funplay-unity-mcp
- **License**: MIT
- **Latest release**: `v0.3.0`

## Summary

Funplay MCP for Unity is a MIT-licensed embedded HTTP MCP server inside the Unity Editor. It exposes the Editor and Play Mode as 91+ Model Context Protocol tools so AI clients (Claude Code, Cursor, Codex, VS Code) can directly drive scene editing, scripts, assets, play mode automation, input simulation, and screenshots.

Distinct from existing entries in this space:

- Single Unity package — no separate Python server or external runtime required
- `execute_code` runs C# snippets in-memory via CodeDom (no `.cs` files written, no domain reload)
- Full Play Mode loop with input simulation (mouse/keyboard) for AI-driven interaction validation
- Already listed on the official MCP Registry as `io.github.FunplayAI/funplay-unity-mcp`

## Checklist

- [x] `package.json` at repo root with valid `name`, `version`, `unity`, `license`
- [x] MIT license file at repo root
- [x] Git tags follow `v<semver>` convention (`v0.3.0` published)
- [x] README.md at repo root
- [x] Image URL verified to return HTTP 200