### PR TITLE
Create so.daro.unity.yml

### DIFF
--- a/data/packages/so.daro.unity.yml
+++ b/data/packages/so.daro.unity.yml
@@ -19,3 +19,4 @@ image: ''
 imageFit: contain
 readme: 'main:README.md'
 hunter: isaac-delightromm
+createdAt: 1778663746000

--- a/data/packages/so.daro.unity.yml
+++ b/data/packages/so.daro.unity.yml
@@ -1,0 +1,21 @@
+name: so.daro.unity
+displayName: Daro Unity SDK
+description: >-
+  Daro ad SDK for Unity. Supports Android and iOS.
+repoUrl: 'https://github.com/delightroom/DaroUnitySDK'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - services
+  - mobile
+  - integration
+gitTagPrefix: 'sdk/'
+gitTagIgnore: '-rc\d*$'
+minVersion: '0.0.2'
+trackingMode: githubRelease
+githubReleaseAssetName: 'so.daro.unity-'
+image: ''
+imageFit: contain
+readme: 'main:README.md'
+hunter: isaac-delightromm


### PR DESCRIPTION
## Package

  Adds `so.daro.unity` to OpenUPM.

  ## Repository

  https://github.com/delightroom/DaroUnitySDK

  ## Notes

  - Unity package path: `SDK/package.json`
  - Git tag prefix: `sdk/`
  - RC tags are ignored with `-rc\d*$`
  - Tracking mode: GitHub Release asset
  - Release asset prefix: `so.daro.unity-`
  - Initial version: `0.0.2`

  This package is the Daro ad mediation adapter for Unity, supporting Android and iOS.