### PR TITLE
Link queue status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ You can also:
 
 ## Status
 
-See <https://openupm.github.io/upptime/>.
+See <https://openupm.github.io/upptime/> for public uptime monitoring and
+<https://openupm.com/queue/> for package scan and release queue status.
 
 ## Production data deploy
 


### PR DESCRIPTION
## Summary
- add the public queue status page link to the README Status section

## Validation
- documentation-only change; reviewed README diff