### PR TITLE
[codex] add missing aliases fields

### DIFF
--- a/data/packages/com.ht.infinitelist.yml
+++ b/data/packages/com.ht.infinitelist.yml
@@ -1,4 +1,5 @@
 name: com.ht.infinitelist
+aliases: []
 displayName: HT Infinitelist
 description: An infinite list scrolling view based on Unity's UGUI.
 repoUrl: https://github.com/FantasyJony/InfiniteList

--- a/data/packages/com.lemonity.editor.yml
+++ b/data/packages/com.lemonity.editor.yml
@@ -1,4 +1,5 @@
 name: com.lemonity.editor
+aliases: []
 displayName: Lemonity Editor
 description: Unity Editor integration for Lemonity hand tracking navigation.
 repoUrl: https://github.com/zorderjohn/lemonity


### PR DESCRIPTION
## Summary
- add missing `aliases: []` to two package metadata files merged shortly before the alias backfill
- verify all package metadata files now include the required aliases field

## Validation
- `rg --files-without-match "^aliases:" data/packages | wc -l` => 0
- `OPENUPM_NEXT_PATH=<openupm-next> npm test`