### PR TITLE
[codex] Add no-PR guidance to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,11 @@ about: Create a report to help us improve
 
 ## Bug report
 
+<!--
+OpenUPM does not accept pull requests for bug fixes unless a maintainer explicitly invites one.
+Please use this issue to share reproduction details, analysis, screenshots, logs, or a high-level fix outline instead of opening a PR.
+-->
+
 #### Bug category
 
 - [ ] Website: issues related to browse or discover packages.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,11 @@ about: Suggest an idea for this project
 
 ## Feature request
 
+<!--
+OpenUPM does not accept pull requests for feature requests unless a maintainer explicitly invites one.
+Please use this issue to describe the user need, expected outcome, examples, and implementation notes instead of opening a PR.
+-->
+
 #### Feature category
 
 - [ ] Website: improve the way to browse or discover packages.


### PR DESCRIPTION
## Summary
- Add hidden guidance to the bug report issue template discouraging unsolicited bug-fix pull requests.
- Add hidden guidance to the feature request issue template discouraging unsolicited feature pull requests.
- Point users toward issue details, analysis, examples, and implementation notes instead.

## Validation
- Template-only Markdown comment change; not run.