### PR TITLE
Create com.badranraza.ide.antigravity.yml

### DIFF
--- a/data/packages/com.badranraza.ide.antigravity.yml
+++ b/data/packages/com.badranraza.ide.antigravity.yml
@@ -1,0 +1,24 @@
+name: com.badranraza.ide.antigravity
+aliases: []
+displayName: Antigravity IDE Editor
+description: |
+  Unity package that integrates Google Antigravity IDE (the VS Code-based code
+  editor in the Antigravity product line) as Unity's External Script Editor.
+  Generates .csproj and .sln files for full C# IntelliSense, supports
+  single-instance window reuse, and reliably distinguishes Antigravity IDE from
+  the standalone Antigravity 2.0 agent app via resources/app/package.json
+  manifest verification.
+repoUrl: https://github.com/BadranRaza/com.unity.ide.antigravity
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - editor-enhancement
+  - integration
+hunter: BadranRaza
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: master:README.md


### PR DESCRIPTION
Adds the `com.badranraza.ide.antigravity` package — a Unity Editor integration for Google Antigravity IDE.

**Repo:** https://github.com/BadranRaza/com.unity.ide.antigravity
**Latest tag:** v2.0.0 (released today; semver, matches `package.json`)
**License:** MIT

### Context — this is a resubmission

The earlier submission ([#6490](https://github.com/openupm/openupm/pull/6490)) used the package name `com.unity.ide.antigravity` and was correctly closed by @favoyang for using the reserved `com.unity.*` namespace. The package has been renamed to `com.badranraza.ide.antigravity` and released as v2.0.0 with a documented breaking-change migration path for existing v1.x users. Thanks for the catch!

### What the package does

Google split the Antigravity product line at I/O 2026 (May 19, 2026) into a standalone agent app (now called "Antigravity") and a separate VS Code-fork code editor ("Antigravity IDE"). Older Antigravity-Unity packages matched any `Antigravity*.exe`, so on machines with both products installed Unity often opened the agent app on every script double-click. This package detects the IDE specifically (filename + `resources/app/package.json` manifest `name` verification) and ignores the agent app.

### Topics chosen

- `editor-enhancement` — Editor-tab External Script Editor integration
- `integration` — integrates Unity with a third-party tool (Antigravity IDE)

Happy to adjust topics, displayName or description if any feel off.