### PR TITLE
Add tracking mode and GitHub release asset name

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.animation.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.animation.yml
@@ -5,7 +5,8 @@ description: >-
   MCP Tools for Animation - Enhance your Unity projects with AI-powered
   Animation tools using the MCP framework.
 repoUrl: https://github.com/IvanMurzak/Unity-AI-Animation
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.animation-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -23,5 +24,3 @@ gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
 createdAt: 1766489712632
-trackingMode: githubRelease
-githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.animation-'

--- a/data/packages/com.ivanmurzak.unity.mcp.animation.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.animation.yml
@@ -23,3 +23,5 @@ gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
 createdAt: 1766489712632
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.animation-'


### PR DESCRIPTION
This pull request updates the package metadata to improve release tracking and asset identification for the Unity MCP Animation package.

Release tracking improvements:

* Added `trackingMode: githubRelease` to enable tracking package releases via GitHub releases.
* Added `githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.animation-'` to specify the naming convention for release assets.