### PR TITLE
Add tracking mode and GitHub release asset name

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.particlesystem.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.particlesystem.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: AI Particle System
 description: "AI-powered tools for Unity ParticleSystem workflow. Inspect and modify ParticleSystem components via natural language commandsâ\x80\x94configure emission, shape, velocity curves, color gradients, and all modules without manual inspector navigation. Ideal for rapid prototyping and procedural effects generation. Built on top of the AI Game Developer (Unity-MCP) platform."
 repoUrl: https://github.com/IvanMurzak/Unity-AI-ParticleSystem
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.particlesystem-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -20,5 +21,3 @@ gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
 createdAt: 1768644041435
-trackingMode: githubRelease
-githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.particlesystem-'

--- a/data/packages/com.ivanmurzak.unity.mcp.particlesystem.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.particlesystem.yml
@@ -20,3 +20,5 @@ gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
 createdAt: 1768644041435
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.particlesystem-'


### PR DESCRIPTION
This pull request updates the package configuration to improve release tracking and asset management. The most important changes are:

Release tracking improvements:
* Added `trackingMode: githubRelease` to enable tracking of package releases via GitHub releases.
* Added `githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.particlesystem-'` to specify the naming convention for release assets.