### PR TITLE
Update tracking mode and add GitHub release asset name

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.yml
@@ -4,7 +4,8 @@ displayName: AI Game Developer — SKILLS, MCP
 description: >-
   AI Skills, MCP Tools, and CLI for Unity Engine. Full AI develop and test loop. Use cli for quick setup. Efficient token usage, advanced tools. Any C# method may be turned into a tool by a single line. Works with Claude Code, Gemini, Copilot, Cursor and any other absolutely for free.
 repoUrl: https://github.com/IvanMurzak/Unity-MCP
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp-'
 parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0


### PR DESCRIPTION
This pull request updates the tracking method for the `com.ivanmurzak.unity.mcp` package to use GitHub Releases instead of direct git tracking, and specifies a release asset name for automated updates.

Package tracking improvements:

* Changed `trackingMode` from `git` to `githubRelease` to enable tracking package updates via GitHub Releases.
* Added `githubReleaseAssetName: 'com.ivanmurzak.unity.mcp-'` to specify which asset to download from each release.