### PR TITLE
Add tracking mode + githubReleaseAssetName for extensions.unity.* packages

### DIFF
--- a/data/packages/extensions.unity.gyroscope.manager.yml
+++ b/data/packages/extensions.unity.gyroscope.manager.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: Unity Gyroscope Manager
 description: Unity Gyroscope manager. Base package for helpful Gyroscope tools.
 repoUrl: 'https://github.com/IvanMurzak/Unity-Gyroscope-Manager'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.gyroscope.manager-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License

--- a/data/packages/extensions.unity.gyroscope.parallax.yml
+++ b/data/packages/extensions.unity.gyroscope.parallax.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: Unity Gyroscope Parallax
 description: Unity Parallax based on gyroscope components.
 repoUrl: 'https://github.com/IvanMurzak/Unity-Gyroscope-Parallax'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.gyroscope.parallax-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License

--- a/data/packages/extensions.unity.mouse.parallax.yml
+++ b/data/packages/extensions.unity.mouse.parallax.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: Unity Mouse Parallax
 description: Unity Parallax based on mouse input.
 repoUrl: 'https://github.com/IvanMurzak/Unity-Mouse-Parallax'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.mouse.parallax-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License

--- a/data/packages/extensions.unity.playerprefsex.yml
+++ b/data/packages/extensions.unity.playerprefsex.yml
@@ -5,7 +5,8 @@ description: >-
   Lightweight package with variables, custom data model support and optional encryption.
   Under the hood it uses the same PlayerPrefs system, but creates flexible wrapper on top.
 repoUrl: 'https://github.com/IvanMurzak/Unity-PlayerPrefsEx'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.playerprefsex-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License

--- a/data/packages/extensions.unity.theme.yml
+++ b/data/packages/extensions.unity.theme.yml
@@ -5,7 +5,8 @@ description: >-
   Create palettes of colors and components for change specific color on a
   specific visual element. Very useful to UI.
 repoUrl: 'https://github.com/IvanMurzak/Unity-Theme'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.theme-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
These five `extensions.unity.*` packages now publish signed UPM tarballs as GitHub Release assets. This PR switches their `trackingMode` from `git` to `githubRelease` and adds the corresponding `githubReleaseAssetName` prefix so OpenUPM consumes the signed release asset instead of building from a git tag.

This mirrors the change made in #6496 (for `com.ivanmurzak.unity.mcp.probuilder`).

Packages updated:
- `extensions.unity.theme`
- `extensions.unity.playerprefsex`
- `extensions.unity.gyroscope.manager`
- `extensions.unity.gyroscope.parallax`
- `extensions.unity.mouse.parallax`

Each file changes one line (`trackingMode: git` → `trackingMode: githubRelease`) and adds one line (`githubReleaseAssetName: '<package-name>-'`). No other fields are touched.