### PR TITLE
chore(data): update com.hungnt.advertisement.yml

### DIFF
--- a/data/packages/com.hungnt.advertisement.yml
+++ b/data/packages/com.hungnt.advertisement.yml
@@ -2,7 +2,7 @@ name: com.hungnt.advertisement
 aliases: []
 displayName: HungNT Advertisement
 description: Ads abstraction (IAdsService), multi-provider implementations (MAX, AdMob, IronSource stubs), and service locator integration.
-repoUrl: 'https://github.com/HungNT-Packages/com.hungnt.advertisement'
+repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.advertisement'
 parentRepoUrl: null
 trackingMode: git
 licenseSpdxId: MIT


### PR DESCRIPTION
Point repoUrl to https://github.com/HungNT-UPM/com.hungnt.advertisement (org renamed from HungNT-Packages).