### PR TITLE
chore(data): update com.hungnt.core.yml

### DIFF
--- a/data/packages/com.hungnt.core.yml
+++ b/data/packages/com.hungnt.core.yml
@@ -2,7 +2,7 @@ name: com.hungnt.core
 aliases: []
 displayName: HungNT Core
 description: Core utilities (HungNT.Core), service locator (HungNT), singletons, extensions, and IService.
-repoUrl: 'https://github.com/HungNT-Packages/com.hungnt.core'
+repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.core'
 parentRepoUrl: null
 trackingMode: git
 licenseSpdxId: MIT


### PR DESCRIPTION
Point repoUrl to https://github.com/HungNT-UPM/com.hungnt.core (org renamed from HungNT-Packages).