### PR TITLE
Change tracking mode to githubRelease

### DIFF
--- a/data/packages/extensions.unity.imageloader.yml
+++ b/data/packages/extensions.unity.imageloader.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: Image Loader
 description: Asynchronous image loading from remote or local destination.
 repoUrl: 'https://github.com/IvanMurzak/Unity-ImageLoader'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.imageloader-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
This pull request updates the package tracking method for the `Image Loader` extension to use GitHub releases instead of direct git tracking. It also specifies the release asset name to be used when fetching releases.

Repository tracking configuration:

* Changed `trackingMode` from `git` to `githubRelease` to enable tracking via GitHub releases.
* Added `githubReleaseAssetName` with the value `'extensions.unity.imageloader-'` to specify which release asset to download.