### PR TITLE
Update readme branch reference from master to main

### DIFF
--- a/data/packages/extensions.unity.imageloader.yml
+++ b/data/packages/extensions.unity.imageloader.yml
@@ -19,7 +19,7 @@ gitTagIgnore: ''
 minVersion: ''
 image: >-
   https://github.com/IvanMurzak/Unity-ImageLoader/raw/d00604bd671838e79e67b3e276dcbcca973d08e0/Test%20Images/ImageA.jpg
-readme: 'master:README.md'
+readme: 'main:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''


### PR DESCRIPTION
This pull request makes a small update to the `data/packages/extensions.unity.imageloader.yml` file. The only change is updating the branch reference for the `readme` file from `master` to `main`.