### PR TITLE
Switch 4 IvanMurzak Unity packages to githubRelease (signed .tgz)

### DIFF
--- a/data/packages/com.github.ivanmurzak.ios.pods.bitcode.yml
+++ b/data/packages/com.github.ivanmurzak.ios.pods.bitcode.yml
@@ -6,7 +6,8 @@ description: >-
   can control bitcode status for all pods from single place. Highly usable with
   CI.
 repoUrl: 'https://github.com/IvanMurzak/Unity-iOS-Pods-Bitcode'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.github.ivanmurzak.ios.pods.bitcode-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -17,7 +18,7 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
 image: ''
-readme: 'master:README.md'
+readme: 'main:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''

--- a/data/packages/extensions.unity.audioloader.yml
+++ b/data/packages/extensions.unity.audioloader.yml
@@ -5,7 +5,8 @@ description: >-
   Asynchronous audio loading from remote or local destination. It has two layers
   of configurable cache system: RAM and Disk.
 repoUrl: 'https://github.com/IvanMurzak/Unity-AudioLoader'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.audioloader-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -17,8 +18,8 @@ hunter: IvanMurzak
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
-image: 'https://github.com/IvanMurzak/Unity-AudioLoader/raw/master/Header.jpg?raw=true'
-readme: 'master:README.md'
+image: 'https://github.com/IvanMurzak/Unity-AudioLoader/raw/main/Header.jpg?raw=true'
+readme: 'main:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''

--- a/data/packages/extensions.unity.bundle.efcore.sqlite.yml
+++ b/data/packages/extensions.unity.bundle.efcore.sqlite.yml
@@ -6,12 +6,13 @@ description: >-
   of packages to provide ready to go solution for Windows, MacOS, Android, iOS
   platforms.
 repoUrl: https://github.com/IvanMurzak/Unity-EFCore-SQLite
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.bundle.efcore.sqlite-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 image: >-
-  https://github.com/IvanMurzak/Unity-EFCore-SQLite/blob/master/efcore_sqlite.jpg?raw=true
+  https://github.com/IvanMurzak/Unity-EFCore-SQLite/raw/main/efcore_sqlite.jpg?raw=true
 topics:
   - data-management
   - frameworks
@@ -21,5 +22,5 @@ hunter: IvanMurzak
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
-readme: master:README.md
+readme: main:README.md
 createdAt: 1733978043643

--- a/data/packages/extensions.unity.nondrawinggraphic.yml
+++ b/data/packages/extensions.unity.nondrawinggraphic.yml
@@ -6,7 +6,8 @@ description: >-
   receive click events. More optimized to have something invisible and clickable
   in Unity UI.
 repoUrl: 'https://github.com/IvanMurzak/Unity-NonDrawingGraphic'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'extensions.unity.nondrawinggraphic-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -18,7 +19,7 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
 image: ''
-readme: 'master:README.md'
+readme: 'main:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''


### PR DESCRIPTION
Switches 4 of my Unity packages from `trackingMode: git` to `trackingMode: githubRelease`, so OpenUPM serves the **Unity-Cloud-signed `.tgz`** uploaded to each GitHub Release instead of rebuilding unsigned from source.

This matches the pattern set by PR #6498 (5 earlier packages) and PR #6495 (the Unity-MCP package).

### Packages

| Package | Asset prefix | First signed release |
|---|---|---|
| `extensions.unity.nondrawinggraphic` | `extensions.unity.nondrawinggraphic-` | [1.0.2](https://github.com/IvanMurzak/Unity-NonDrawingGraphic/releases/tag/1.0.2) |
| `extensions.unity.audioloader` | `extensions.unity.audioloader-` | [1.0.5](https://github.com/IvanMurzak/Unity-AudioLoader/releases/tag/1.0.5) |
| `com.github.ivanmurzak.ios.pods.bitcode` | `com.github.ivanmurzak.ios.pods.bitcode-` | [1.0.1](https://github.com/IvanMurzak/Unity-iOS-Pods-Bitcode/releases/tag/1.0.1) |
| `extensions.unity.bundle.efcore.sqlite` | `extensions.unity.bundle.efcore.sqlite-` | [0.1.2](https://github.com/IvanMurzak/Unity-EFCore-SQLite/releases/tag/0.1.2) |

Each release ships a signed `.tgz` and an installer `.unitypackage`, produced by the same game-ci + Unity Cloud signing pipeline used by my other packages already on `githubRelease` here.

### Drive-by fix
Also corrects stale `master:README.md` / `raw/master/` references to `main:README.md` / `raw/main/` for these four — the default branches were renamed from `master` to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)