### PR TITLE
Add com.ivanmurzak.unity.mcp.cinemachine (AI Cinemachine)

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.cinemachine.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.cinemachine.yml
@@ -14,7 +14,6 @@ image: >-
   https://github.com/IvanMurzak/Unity-AI-Cinemachine/raw/main/docs/img/ai-game-dev.gif
 topics:
   - ai
-  - cinemachine
   - camera
   - editor-enhancement
   - integration

--- a/data/packages/com.ivanmurzak.unity.mcp.cinemachine.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.cinemachine.yml
@@ -1,0 +1,26 @@
+name: com.ivanmurzak.unity.mcp.cinemachine
+aliases: []
+displayName: AI Cinemachine
+description: >-
+  MCP Tools for Cinemachine - Enhance your Unity projects with AI-powered
+  Cinemachine camera tools using the MCP framework.
+repoUrl: https://github.com/IvanMurzak/Unity-AI-Cinemachine
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.cinemachine-'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: >-
+  https://github.com/IvanMurzak/Unity-AI-Cinemachine/raw/main/docs/img/ai-game-dev.gif
+topics:
+  - ai
+  - cinemachine
+  - camera
+  - editor-enhancement
+  - integration
+hunter: IvanMurzak
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1780539094065


### PR DESCRIPTION
New Unity-MCP extension package.

- **Package**: `com.ivanmurzak.unity.mcp.cinemachine` (AI Cinemachine)
- **Repo**: https://github.com/IvanMurzak/Unity-AI-Cinemachine
- **License**: MIT
- AI-powered Cinemachine camera tools for Unity, built on the AI Game Developer (Unity-MCP) platform. Wraps Cinemachine 3.x (min Unity 2022.3 LTS).
- Tracking via signed GitHub Releases (`githubReleaseAssetName: com.ivanmurzak.unity.mcp.cinemachine-`); first release `1.0.0` is published with a signed UPM `.tgz`.

Sibling extensions already on OpenUPM: com.ivanmurzak.unity.mcp.animation / .particlesystem / .probuilder.