### PR TITLE
chore(data): set displayName = package name for com.hungnt.* packages

### DIFF
--- a/data/packages/com.hungnt.advertisement.yml
+++ b/data/packages/com.hungnt.advertisement.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.advertisement
 aliases: []
-displayName: HungNT Advertisement
+displayName: com.hungnt.advertisement
 description: Ads abstraction (IAdsService), multi-provider implementations (MAX, AdMob, IronSource stubs), and service locator integration.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.advertisement'
 parentRepoUrl: null

--- a/data/packages/com.hungnt.core.yml
+++ b/data/packages/com.hungnt.core.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.core
 aliases: []
-displayName: HungNT Core
+displayName: com.hungnt.core
 description: Core utilities (HungNT.Core), service locator (HungNT), singletons, general extensions, and IService. Odin is an external dependency.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.core'
 parentRepoUrl: null

--- a/data/packages/com.hungnt.database.yml
+++ b/data/packages/com.hungnt.database.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.database
 aliases: []
-displayName: HungNT Database
+displayName: com.hungnt.database
 description: ScriptableObject database service, Google Sheet import (editor), and GGSheet attributes.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.database'
 parentRepoUrl: null

--- a/data/packages/com.hungnt.datasave.yml
+++ b/data/packages/com.hungnt.datasave.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.datasave
 aliases: []
-displayName: HungNT Datasave
+displayName: com.hungnt.datasave
 description: Multi-domain save/load with BaseSaveData, DatasaveService, and Odin Serialization JSON.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.datasave'
 parentRepoUrl: null

--- a/data/packages/com.hungnt.eventbus.yml
+++ b/data/packages/com.hungnt.eventbus.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.eventbus
 aliases: []
-displayName: HungNT Event Bus
+displayName: com.hungnt.eventbus
 description: Type-safe event bus singleton, extensions, and Odin-backed editor inspector.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.eventbus'
 parentRepoUrl: null

--- a/data/packages/com.hungnt.ui.tween.yml
+++ b/data/packages/com.hungnt.ui.tween.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.ui.tween
 aliases: []
-displayName: HungNT UI Tween
+displayName: com.hungnt.ui.tween
 description: UI show/hide animation components using DOTween, UniTask, and TweenPreset ScriptableObjects.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.ui.tween'
 parentRepoUrl: null

--- a/data/packages/com.hungnt.ui.yml
+++ b/data/packages/com.hungnt.ui.yml
@@ -1,6 +1,6 @@
 name: com.hungnt.ui
 aliases: []
-displayName: HungNT UI
+displayName: com.hungnt.ui
 description: UIViewBase and UIScaleFeedback for Unity UI elements.
 repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.ui'
 parentRepoUrl: null


### PR DESCRIPTION
## Summary

Update `displayName` to match the package name exactly for all `com.hungnt.*` packages. Previously these used human-readable names (e.g. `HungNT UI`) which differed from the package name — updating for consistency.

| Package | Old displayName | New displayName |
|---------|----------------|-----------------|
| com.hungnt.advertisement | HungNT Advertisement | com.hungnt.advertisement |
| com.hungnt.core | HungNT Core | com.hungnt.core |
| com.hungnt.database | HungNT Database | com.hungnt.database |
| com.hungnt.datasave | HungNT Datasave | com.hungnt.datasave |
| com.hungnt.eventbus | HungNT Event Bus | com.hungnt.eventbus |
| com.hungnt.ui.tween | HungNT UI Tween | com.hungnt.ui.tween |
| com.hungnt.ui | HungNT UI | com.hungnt.ui |