### PR TITLE
Add com.ivanmurzak.unity.mcp.terrain (AI Terrain)

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.terrain.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.terrain.yml
@@ -23,3 +23,4 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
+createdAt: 1780559770843

--- a/data/packages/com.ivanmurzak.unity.mcp.terrain.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.terrain.yml
@@ -1,0 +1,25 @@
+name: com.ivanmurzak.unity.mcp.terrain
+aliases: []
+displayName: AI Terrain
+description: >-
+  MCP Tools for Unity Terrain - Enhance your Unity projects with AI-powered
+  terrain authoring tools using the MCP framework.
+repoUrl: https://github.com/IvanMurzak/Unity-AI-Terrain
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.terrain-'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: >-
+  https://github.com/IvanMurzak/Unity-AI-Terrain/raw/main/docs/img/ai-game-dev.gif
+topics:
+  - ai
+  - terrain
+  - procedural-generation
+  - editor-enhancement
+  - integration
+hunter: IvanMurzak
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md


### PR DESCRIPTION
Adds the AI Terrain extension for Unity-MCP. Repo: https://github.com/IvanMurzak/Unity-AI-Terrain. Ships a signed UPM .tgz Release asset (githubRelease tracking).