### PR TITLE
Add com.ivanmurzak.unity.mcp.inputsystem (AI InputSystem)

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.inputsystem.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.inputsystem.yml
@@ -1,0 +1,24 @@
+name: com.ivanmurzak.unity.mcp.inputsystem
+aliases: []
+displayName: AI InputSystem
+description: >-
+  MCP Tools for the Unity Input System - Enhance your Unity projects with
+  AI-powered Input System tools using the MCP framework.
+repoUrl: https://github.com/IvanMurzak/Unity-AI-InputSystem
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.inputsystem-'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: >-
+  https://github.com/IvanMurzak/Unity-AI-InputSystem/raw/main/docs/img/ai-game-dev.gif
+topics:
+  - ai
+  - input-management
+  - editor-enhancement
+  - integration
+hunter: IvanMurzak
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md

--- a/data/packages/com.ivanmurzak.unity.mcp.inputsystem.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.inputsystem.yml
@@ -22,3 +22,4 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
+createdAt: 1780555125933


### PR DESCRIPTION
Adds the AI InputSystem extension for Unity-MCP. Repo: https://github.com/IvanMurzak/Unity-AI-InputSystem. Ships a signed UPM .tgz Release asset (githubRelease tracking).