### PR TITLE
Add com.ivanmurzak.unity.mcp.timeline (AI Timeline)

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.timeline.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.timeline.yml
@@ -1,0 +1,25 @@
+name: com.ivanmurzak.unity.mcp.timeline
+aliases: []
+displayName: AI Timeline
+description: >-
+  MCP Tools for Unity Timeline - Author cutscenes and sequences with AI-powered
+  Timeline tools using the MCP framework.
+repoUrl: https://github.com/IvanMurzak/Unity-AI-Timeline
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.ivanmurzak.unity.mcp.timeline-'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: >-
+  https://github.com/IvanMurzak/Unity-AI-Timeline/raw/main/docs/img/ai-game-dev.gif
+topics:
+  - ai
+  - animation
+  - editor-enhancement
+  - integration
+hunter: IvanMurzak
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1780539094065


### PR DESCRIPTION
Adds the AI Timeline extension for Unity-MCP. Repo: https://github.com/IvanMurzak/Unity-AI-Timeline. Ships a signed UPM .tgz Release asset (githubRelease tracking).