### PR TITLE
chore(data): add com.hungnt.dataconfig

### DIFF
--- a/data/packages/com.hungnt.dataconfig.yml
+++ b/data/packages/com.hungnt.dataconfig.yml
@@ -1,0 +1,16 @@
+name: com.hungnt.dataconfig
+aliases: []
+displayName: com.hungnt.dataconfig
+description: ScriptableObject data config service, Google Sheet import (editor), and GGSheet attributes.
+repoUrl: 'https://github.com/HungNT-UPM/com.hungnt.dataconfig'
+parentRepoUrl: null
+trackingMode: git
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - utilities
+  - data-management
+hunter: NgTienHungg
+gitTagPrefix: ''
+gitTagIgnore: ''
+createdAt: 1748188800000


### PR DESCRIPTION
Add `com.hungnt.dataconfig`, renamed from `com.hungnt.database`.

The GitHub repo `HungNT-UPM/com.hungnt.database` was renamed to `HungNT-UPM/com.hungnt.dataconfig`, and the package `name` in `package.json` is now `com.hungnt.dataconfig` (since v1.1.0). It therefore needs its own OpenUPM entry. This mirrors the earlier `com.hungnt.eventdispatcher` → `com.hungnt.eventbus` rename.

- repo: https://github.com/HungNT-UPM/com.hungnt.dataconfig
- first release as dataconfig: 1.1.0

The legacy `com.hungnt.database` entry remains frozen at its last matching release (1.0.6); OpenUPM matches the `package.json` name per tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)