### PR TITLE
Update image for com.ivanmurzak.unity.mcp.particlesystem

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.particlesystem.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.particlesystem.yml
@@ -9,7 +9,7 @@ parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 image: >-
-  https://github.com/IvanMurzak/Unity-AI-ParticleSystem/blob/main/docs/img/GitHub%20Promo.jpg?raw=true
+  https://github.com/IvanMurzak/Unity-AI-ParticleSystem/raw/main/docs/img/particle-system-glitch.gif
 topics:
   - ai
   - editor-enhancement


### PR DESCRIPTION
Updates the package preview image to the new animated promo GIF (replaces the old static GitHub Promo.jpg). The GIF lives at docs/img/particle-system-glitch.gif in the package repo.