### PR TITLE
Update image for com.ivanmurzak.unity.mcp

### DIFF
--- a/data/packages/com.ivanmurzak.unity.mcp.yml
+++ b/data/packages/com.ivanmurzak.unity.mcp.yml
@@ -10,7 +10,7 @@ parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 image: >-
-  https://github.com/IvanMurzak/Unity-MCP/blob/main/docs/img/promo/ai-developer-banner.jpg?raw=true
+  https://github.com/IvanMurzak/Unity-MCP/raw/main/docs/img/promo/ai-developer-banner-glitch.gif
 topics:
   - ai
   - code-generation


### PR DESCRIPTION
Updates the package preview image to the animated promo GIF (replaces the static ai-developer-banner.jpg). The GIF lives at docs/img/promo/ai-developer-banner-glitch.gif in the package repo.