### PR TITLE
Add the "unity" suffix to the Unity extension package.

### DIFF
--- a/data/packages/com.cysharp.memorypack.yml
+++ b/data/packages/com.cysharp.memorypack.yml
@@ -1,6 +1,6 @@
 name: com.cysharp.memorypack
 aliases: []
-displayName: MemoryPack
+displayName: MemoryPack.Unity
 description: Zero encoding extreme performance binary serializer for C#.
 repoUrl: 'https://github.com/Cysharp/MemoryPack'
 trackingMode: git

--- a/data/packages/com.cysharp.r3.yml
+++ b/data/packages/com.cysharp.r3.yml
@@ -1,6 +1,6 @@
 name: com.cysharp.r3
 aliases: []
-displayName: R3
+displayName: R3.Unity
 description: Reactive Extensions for Unity.
 repoUrl: https://github.com/Cysharp/R3
 trackingMode: git

--- a/data/packages/com.cysharp.zlinq.yml
+++ b/data/packages/com.cysharp.zlinq.yml
@@ -1,6 +1,6 @@
 name: com.cysharp.zlinq
 aliases: []
-displayName: ZLinq
+displayName: ZLinq.Unity
 description: >-
   Zero allocation LINQ with Span and LINQ to SIMD, LINQ to Tree(FileSystem,
   GameObject, etc...) for all .NET platforms and Unity.


### PR DESCRIPTION
Distinguish between the core package and the Unity extension package.