### PR TITLE
Add LogBrew Unity package image

### DIFF
--- a/data/packages/co.logbrew.unity.yml
+++ b/data/packages/co.logbrew.unity.yml
@@ -17,7 +17,7 @@ hunter: 'furkanerday'
 gitTagPrefix: 'co.logbrew.unity/'
 gitTagIgnore: ''
 minVersion: '0.1.0'
-image: ''
+image: 'https://raw.githubusercontent.com/LogBrewCo/sdk/main/assets/brand/logbrew-logo-espresso-bg-512.png'
 readme: 'main:unity/logbrew-unity/README.md'
 createdAt: 1780778637391
 readme_zhCN: ''


### PR DESCRIPTION
Adds the LogBrew logo image URL to `co.logbrew.unity` package metadata.

Validation:
- `ruby -e 'require "yaml"; data = YAML.load_file("data/packages/co.logbrew.unity.yml"); abort "wrong image" unless data["image"] == "https://raw.githubusercontent.com/LogBrewCo/sdk/main/assets/brand/logbrew-logo-espresso-bg-512.png"; puts "openupm package yaml ok"'`\n- `curl -fsSI https://raw.githubusercontent.com/LogBrewCo/sdk/main/assets/brand/logbrew-logo-espresso-bg-512.png` returned HTTP 200 and `content-type: image/png`.\n\nNote: `npm test` was not runnable in this isolated checkout because it requires a built `openupm-next` checkout via `OPENUPM_NEXT_PATH`.