### PR TITLE
Add com.yifei.easyframework

### DIFF
--- a/data/packages/com.yifei.easyframework.yml
+++ b/data/packages/com.yifei.easyframework.yml
@@ -17,3 +17,4 @@ image: 'https://github.com/whimwindgames/EasyFramework-Unity/raw/main/docs/brand
 readme: 'main:README.md'
 displayName_zhCN: EasyFramework
 description_zhCN: 开箱即用的 Unity 2D 移动游戏复用底座。VContainer 依赖注入内核 + 静态门面,服务层全部接口化,商业化层(广告/内购/统计)可整体替换而不改业务代码。
+createdAt: 1781294348466

--- a/data/packages/com.yifei.easyframework.yml
+++ b/data/packages/com.yifei.easyframework.yml
@@ -1,0 +1,19 @@
+name: com.yifei.easyframework
+aliases: []
+displayName: EasyFramework
+description: An out-of-the-box reusable foundation for Unity 2D mobile games. VContainer DI core plus a static facade, a fully interface-based service layer, and a swappable monetization layer (ads, IAP, analytics).
+repoUrl: 'https://github.com/whimwindgames/EasyFramework-Unity'
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+hunter: whimwindgames
+gitTagPrefix: 'v'
+gitTagIgnore: ''
+minVersion: ''
+image: 'https://github.com/whimwindgames/EasyFramework-Unity/raw/main/docs/branding/banner.png'
+readme: 'main:README.md'
+displayName_zhCN: EasyFramework
+description_zhCN: 开箱即用的 Unity 2D 移动游戏复用底座。VContainer 依赖注入内核 + 静态门面,服务层全部接口化,商业化层(广告/内购/统计)可整体替换而不改业务代码。


### PR DESCRIPTION
Adds EasyFramework — an out-of-the-box reusable foundation for Unity 2D mobile games.

- Repo: https://github.com/whimwindgames/EasyFramework-Unity
- Package: `com.yifei.easyframework` (at `Packages/com.yifei.easyframework`)
- License: MIT
- Latest tag: v0.1.0
- Unity 6000.0+; deps resolved via OpenUPM (UniTask, VContainer, MessagePipe, PrimeTween, IngameDebugConsole)