### PR TITLE
Add configuration for Unity Figma Importer package

### DIFF
--- a/data/packages/com.cdm.figma.ui.yml
+++ b/data/packages/com.cdm.figma.ui.yml
@@ -1,0 +1,20 @@
+name: com.cdm.figma.ui
+aliases: []
+displayName: Unity Figma Importer - UGUI
+description: >-
+  Unity Figma Importer turns your Figma design into Unity UI elements and can
+  generate code and layout files to create Unity apps.
+repoUrl: https://github.com/cdmvision/unity-figma-importer
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - gui
+hunter: IvanMurzak
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: master:README.md
+createdAt: 1781307687332


### PR DESCRIPTION
This pull request adds a new package definition for the Unity Figma Importer, which enables importing Figma designs into Unity as UI elements. The change introduces metadata and configuration for the package.

New package addition:

* Added a new package configuration file `data/packages/com.cdm.figma.ui.yml` for the Unity Figma Importer, including details such as name, description, repository URL, license, topics, and maintainer information.