### PR TITLE
chore(data): add com.example.openupm-action

### DIFF
--- a/data/packages/com.example.openupm-action.yml
+++ b/data/packages/com.example.openupm-action.yml
@@ -1,0 +1,18 @@
+name: com.example.openupm-action
+aliases: []
+displayName: OpenUPM Action Example
+description: Minimal Unity package demonstrating the OpenUPM publish wait GitHub Action.
+repoUrl: https://github.com/openupm/com.example.openupm-action
+trackingMode: git
+parentRepoUrl: null
+licenseName: MIT License
+licenseSpdxId: MIT
+image: ''
+topics:
+- package-management
+hunter: favoyang
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 1.0.0
+readme: main:README.md
+createdAt: 1781395200000


### PR DESCRIPTION
## Summary

- Add package data for `com.example.openupm-action`.
- Repository URL: https://github.com/openupm/com.example.openupm-action
- Tracking mode: `git`
- License: MIT License (`MIT`)

## Validation

- OPENUPM_NEXT_PATH=<openupm-next-worktree> npm test

## Notes

- This package is the public demo repository for the OpenUPM GitHub Action workflow.
- The initial demo tag is intentionally deferred until the API/docs PR is ready and deployed.