### PR TITLE
com.appegy.binary-prefs: serve signed GitHub Release asset

### DIFF
--- a/data/packages/com.appegy.binary-prefs.yml
+++ b/data/packages/com.appegy.binary-prefs.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: 'Appegy: Binary Prefs'
 description: Fast persistant thread-safe binary storage for Unity.
 repoUrl: https://github.com/Appegy/BinaryPrefs
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseName: MIT License
 licenseSpdxId: MIT


### PR DESCRIPTION
Switch `com.appegy.binary-prefs` to `trackingMode: githubRelease` so OpenUPM serves the signed `.tgz` from GitHub Releases (now signed via the Unity UPM CLI; latest: v1.0.6) instead of building from source.