### PR TITLE
com.appegy.unilogger: serve signed GitHub Release asset

### DIFF
--- a/data/packages/com.appegy.unilogger.yml
+++ b/data/packages/com.appegy.unilogger.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: 'Appegy: UniLogger'
 description: Simple and flexible but lightweight logger for Unity.
 repoUrl: https://github.com/Appegy/UniLogger
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
Switch `com.appegy.unilogger` to `trackingMode: githubRelease` so OpenUPM serves the signed `.tgz` from GitHub Releases (now signed via the Unity UPM CLI; latest: v1.0.2) instead of building from source.