### PR TITLE
com.appegy.union: serve signed GitHub Release asset

### DIFF
--- a/data/packages/com.appegy.union.yml
+++ b/data/packages/com.appegy.union.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: 'Appegy: Union'
 description: Struct union for Unity.
 repoUrl: https://github.com/Appegy/Union
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
Switch `com.appegy.union` to `trackingMode: githubRelease` so OpenUPM serves the signed `.tgz` from GitHub Releases (now signed via the Unity UPM CLI; latest: v1.0.3) instead of building from source.