### PR TITLE
com.appegy.ios-att-localization: serve signed GitHub Release asset

### DIFF
--- a/data/packages/com.appegy.ios-att-localization.yml
+++ b/data/packages/com.appegy.ios-att-localization.yml
@@ -6,7 +6,7 @@ description: Provides localization of App Tracking Transparency (ATT) descriptio
   for tracking the user or the iOS device. Perfectly works with Unity's iOS 14 Advertising
   Support package.
 repoUrl: https://github.com/Appegy/iOS-ATT-Localization
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseName: MIT License
 licenseSpdxId: MIT


### PR DESCRIPTION
Switch `com.appegy.ios-att-localization` to `trackingMode: githubRelease` so OpenUPM serves the signed `.tgz` from GitHub Releases (now signed via the Unity UPM CLI; latest: v1.0.4) instead of building from source.