### PR TITLE
chore(data): new package com.burakk.unity-editor-mcp

### DIFF
--- a/data/packages/com.burakk.unity-editor-mcp.yml
+++ b/data/packages/com.burakk.unity-editor-mcp.yml
@@ -1,0 +1,26 @@
+name: com.burakk.unity-editor-mcp
+aliases: []
+displayName: Unity Editor MCP
+description: >-
+  Unity Editor integration with Model Context Protocol (MCP) for AI-assisted
+  development
+repoUrl: 'https://github.com/burakaydinofficial/unity-editor-mcp'
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - ai
+  - asset-management
+  - debugging-and-logging
+  - editor-enhancement
+  - integration
+  - testing
+  - utilities
+hunter: burakaydinofficial
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.19.0
+readme: 'main:README.md'
+createdAt: 1782107017937


### PR DESCRIPTION
New package submission: **com.burakk.unity-editor-mcp** (Unity Editor MCP) — an MCP bridge that lets AI assistants drive the Unity Editor. MIT, public repo (burakaydinofficial/unity-editor-mcp), tagged v0.19.0, min build version 0.19.0.