### PR TITLE
tracking mode change for today.comes.saintsfield

### DIFF
--- a/data/packages/today.comes.saintsfield.yml
+++ b/data/packages/today.comes.saintsfield.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: SaintsField
 description: A Unity plugin for field in inspector
 repoUrl: https://github.com/TylerTemp/SaintsField
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
change tracking mode to `githubRelease`, as I'm gonna include `today.comes.saintsfield-x.x.x.tgz` in my next release