### PR TITLE
update com.vrmc.gltf, com.vrmc.univrm and com.vrmc.vrm (vrm-c)

### DIFF
--- a/data/packages/com.vrmc.gltf.yml
+++ b/data/packages/com.vrmc.gltf.yml
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - ar-and-vr
   - modeling
-hunter: vrm-c
+hunter: esperecyan
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: v0.81.0

--- a/data/packages/com.vrmc.gltf.yml
+++ b/data/packages/com.vrmc.gltf.yml
@@ -1,7 +1,7 @@
 name: com.vrmc.gltf
 aliases: []
 displayName: UniGLTF
-description: GLTF importer and exporter
+description: glTF 2.0 importer and exporter for Unity.
 repoUrl: 'https://github.com/vrm-c/UniVRM'
 trackingMode: git
 parentRepoUrl: null
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - ar-and-vr
   - modeling
-hunter: esperecyan
+hunter: vrm-c
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: v0.81.0

--- a/data/packages/com.vrmc.univrm.yml
+++ b/data/packages/com.vrmc.univrm.yml
@@ -1,7 +1,7 @@
 name: com.vrmc.univrm
 aliases: []
-displayName: VRM
-description: Unity package that can import and export VRM format
+displayName: UniVRM VRM 0.x
+description: VRM 0.x importer and exporter for Unity.
 repoUrl: 'https://github.com/vrm-c/UniVRM'
 trackingMode: git
 parentRepoUrl: null
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - ar-and-vr
   - modeling
-hunter: JesseTG
+hunter: vrm-c
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''

--- a/data/packages/com.vrmc.univrm.yml
+++ b/data/packages/com.vrmc.univrm.yml
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - ar-and-vr
   - modeling
-hunter: vrm-c
+hunter: JesseTG
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''

--- a/data/packages/com.vrmc.vrm.yml
+++ b/data/packages/com.vrmc.vrm.yml
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - ar-and-vr
   - modeling
-hunter: vrm-c
+hunter: esperecyan
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: v0.81.0

--- a/data/packages/com.vrmc.vrm.yml
+++ b/data/packages/com.vrmc.vrm.yml
@@ -1,7 +1,7 @@
 name: com.vrmc.vrm
 aliases: []
-displayName: VRM-1.0β
-description: VRM-1.0β importer
+displayName: UniVRM VRM 1.0
+description: VRM 1.0 importer and exporter for Unity.
 repoUrl: 'https://github.com/vrm-c/UniVRM'
 trackingMode: git
 parentRepoUrl: null
@@ -10,7 +10,7 @@ licenseName: MIT License
 topics:
   - ar-and-vr
   - modeling
-hunter: esperecyan
+hunter: vrm-c
 gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: v0.81.0


### PR DESCRIPTION
The VRM Consortium officially recommends the OpenUPM version.
Some minor wording adjustments, etc.

`com.vrmc.vrmshaders` is no longer being updated, so it will remain unchanged.