### PR TITLE
chore(data): fix binhou batchrenamer readme

### DIFF
--- a/data/packages/com.binhou.batchrenamer.yml
+++ b/data/packages/com.binhou.batchrenamer.yml
@@ -18,5 +18,5 @@ hunter: BinhouOuO
 gitTagPrefix: rename/
 gitTagIgnore: ''
 minVersion: ''
-readme: main:README.md
+readme: main:Packages/com.binhou.batchrenamer/README.md
 createdAt: 1782374840150


### PR DESCRIPTION
## Summary
- update com.binhou.batchrenamer to use the package-local README path
- keep the existing package source and tracking metadata unchanged

## Validation
- npm test
- verified the package-local README path exists in the source repository