### PR TITLE
ci: comment on data validation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, 'skip ci') }}
     name: Data validation
+    permissions:
+      contents: read
+      issues: write
     steps:
     - uses: actions/checkout@v4
     - name: checkout openupm-next validator source
@@ -35,7 +38,22 @@ jobs:
       run: npm run build -- --filter @openupm/local-data
       working-directory: tmp-openupm-next
     - name: npm test
-      run: OPENUPM_NEXT_PATH=tmp-openupm-next npm test
+      id: data_validation
+      run: |
+        set +e
+        OPENUPM_NEXT_PATH=tmp-openupm-next npm test > data-validation-output.txt 2>&1
+        status=$?
+        cat data-validation-output.txt
+        exit "$status"
+    - name: Comment on data validation failures
+      if: ${{ failure() && steps.data_validation.outcome == 'failure' && github.event_name == 'pull_request' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        node scripts/data-validation-pr-comment.js \
+          --validation-output data-validation-output.txt \
+          --repo "$GITHUB_REPOSITORY" \
+          --issue "${{ github.event.pull_request.number }}"
 
   build-website:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/openupm/openupm.git",
   "scripts": {
     "test": "npm run test:data",
-    "test:data": "NODE_ENV=test node --test test/data-packages.js"
+    "test:data": "NODE_ENV=test node --test test/*.js"
   },
   "license": "BSD 3-Clause"
 }

--- a/scripts/data-validation-pr-comment.js
+++ b/scripts/data-validation-pr-comment.js
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+const fs = require("fs");
+
+const marker = "<!-- openupm-data-validation-comment -->";
+const githubApiBase = process.env.GITHUB_API_URL || "https://api.github.com";
+
+const fixableIssues = {
+  "package-license-spdx-id-empty": {
+    title: "Fill in `licenseSpdxId` or set it to `null`",
+    guidance:
+      "`licenseSpdxId` cannot be an empty string. Use a valid SPDX id such as `MIT`, or use `null` for a custom/non-SPDX license.",
+    duplicateTerms: ["licensespdxid", "empty string"],
+  },
+  "package-license-spdx-id-invalid": {
+    title: "Use a valid SPDX license id",
+    guidance:
+      "`licenseSpdxId` must match an SPDX license id, for example `MIT`, `Apache-2.0`, or `BSD-3-Clause`.",
+    duplicateTerms: ["licensespdxid", "spdx"],
+  },
+  "package-license-name-spdx-mismatch": {
+    title: "Match `licenseName` to `licenseSpdxId`",
+    guidance:
+      "When `licenseSpdxId` is set, `licenseName` must use the canonical SPDX license name reported by validation.",
+    duplicateTerms: ["licensename", "licensespdxid"],
+  },
+  "package-topic-invalid": {
+    title: "Use an existing topic slug",
+    guidance:
+      "`topics` must contain OpenUPM topic slugs that already exist in `data/topics.yml`.",
+    duplicateTerms: ["topic", "topics.yml"],
+  },
+  "package-scope-blocked": {
+    title: "Choose a package name outside blocked scopes",
+    guidance:
+      "The submitted package name matches a blocked scope. Rename the package metadata or ask a maintainer if the scope should be allowed.",
+    duplicateTerms: ["blocked", "scope"],
+  },
+  "package-name-filename-mismatch": {
+    title: "Make the filename match `name`",
+    guidance:
+      "The package file must be named after the package id, for example `data/packages/com.example.tool.yml` for `name: com.example.tool`.",
+    duplicateTerms: ["filename", "name"],
+  },
+  "package-repo-url-empty": {
+    title: "Add `repoUrl`",
+    guidance: "`repoUrl` is required and must point to the package source repository.",
+    duplicateTerms: ["repourl"],
+  },
+  "package-name-empty": {
+    title: "Add `name`",
+    guidance: "`name` is required and must contain the Unity package id.",
+    duplicateTerms: ["name", "required"],
+  },
+  "package-license-name-empty": {
+    title: "Add `licenseName`",
+    guidance: "`licenseName` is required. Use the license name shown by the repository or SPDX.",
+    duplicateTerms: ["licensename"],
+  },
+  "package-hunter-empty": {
+    title: "Add `hunter`",
+    guidance:
+      "`hunter` is required and should be the GitHub user who submitted or maintains the package metadata. It does not have to match the package repository owner.",
+    duplicateTerms: ["hunter"],
+  },
+};
+
+const metadataRequiredFields = [
+  "name",
+  "aliases",
+  "repoUrl",
+  "displayName",
+  "description",
+  "licenseSpdxId",
+  "licenseName",
+  "topics",
+  "hunter",
+  "createdAt",
+  "trackingMode",
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    const name = arg.slice(2);
+    if (name === "dry-run") {
+      args.dryRun = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${name}`);
+    }
+    args[name] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function parseValidationIssues(output) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .map((line) =>
+      line.match(
+        /^(?:(?<path>packages\/[^:]+|[A-Za-z0-9_.-]+\.ya?ml|packages): )?(?<message>.+) \[(?<code>[a-z0-9-]+)\]$/
+      )
+    )
+    .filter(Boolean)
+    .map((match) => ({
+      path: match.groups.path,
+      message: match.groups.message,
+      code: match.groups.code,
+    }));
+}
+
+function metadataGuidance(issue) {
+  if (issue.code !== "package-metadata-invalid") return null;
+  const field = metadataRequiredFields.find((candidate) =>
+    new RegExp(`\\b${candidate}\\b`, "i").test(issue.message)
+  );
+  if (!field) return null;
+  return {
+    title: `Fix package metadata field \`${field}\``,
+    guidance: `The package YAML is missing or has an invalid \`${field}\` value. Please update that field in the submitted package file.`,
+    duplicateTerms: [field.toLowerCase()],
+  };
+}
+
+function contributorFixForIssue(issue) {
+  return fixableIssues[issue.code] || metadataGuidance(issue);
+}
+
+function normalizeBody(body) {
+  return String(body || "").toLowerCase();
+}
+
+function hasExistingMaintainerGuidance(comments, fix) {
+  return comments.some((comment) => {
+    const body = normalizeBody(comment.body);
+    if (body.includes(marker)) return false;
+    const userType = comment.user && comment.user.type;
+    if (userType === "Bot") return false;
+    return fix.duplicateTerms.every((term) => body.includes(term.toLowerCase()));
+  });
+}
+
+function buildCommentBody(issues, comments = []) {
+  const analyzed = issues.map((issue) => ({
+    issue,
+    fix: contributorFixForIssue(issue),
+  }));
+  const fixable = analyzed
+    .filter((entry) => entry.fix)
+    .filter((entry) => !hasExistingMaintainerGuidance(comments, entry.fix));
+  const unsupported = analyzed.filter((entry) => !entry.fix);
+
+  if (fixable.length === 0 && unsupported.length === 0) return null;
+
+  const lines = [
+    marker,
+    fixable.length > 0
+      ? "Data validation found package metadata issues that look contributor-fixable:"
+      : "Data validation failed, but this bot does not have specific guidance for the reported reason.",
+    "",
+  ];
+
+  for (const { issue, fix } of fixable.slice(0, 8)) {
+    const location = issue.path ? ` in \`${issue.path}\`` : "";
+    lines.push(`- ${fix.title}${location}: ${fix.guidance}`);
+    lines.push(`  Validation detail: ${issue.message} \`${issue.code}\``);
+  }
+
+  if (fixable.length > 8) {
+    lines.push(`- ${fixable.length - 8} additional fixable validation issue(s) were omitted from this summary.`);
+  }
+
+  if (unsupported.length > 0) {
+    if (fixable.length > 0) lines.push("");
+    lines.push(
+      "Other validation failure details are only available in the `Data validation` CI report. Please open that check and review the full log."
+    );
+  }
+
+  lines.push("");
+  lines.push("Please update the package data and push another commit to rerun validation.");
+  return lines.join("\n");
+}
+
+async function githubRequest(method, path, token, body) {
+  const response = await fetch(`${githubApiBase}${path}`, {
+    method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${method} ${path} failed with ${response.status}: ${text}`);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function listComments(repo, issue, token) {
+  return githubRequest(
+    "GET",
+    `/repos/${repo}/issues/${issue}/comments?per_page=100`,
+    token
+  );
+}
+
+async function upsertComment(repo, issue, token, body) {
+  const comments = await listComments(repo, issue, token);
+  const markerComments = comments.filter((comment) =>
+    String(comment.body || "").includes(marker) &&
+    comment.user &&
+    comment.user.type === "Bot"
+  );
+
+  if (!body) {
+    await Promise.all(
+      markerComments.map((comment) =>
+        githubRequest("DELETE", `/repos/${repo}/issues/comments/${comment.id}`, token)
+      )
+    );
+    return { action: markerComments.length ? "deleted" : "skipped" };
+  }
+
+  const [first, ...extra] = markerComments;
+  if (first) {
+    await githubRequest("PATCH", `/repos/${repo}/issues/comments/${first.id}`, token, {
+      body,
+    });
+    await Promise.all(
+      extra.map((comment) =>
+        githubRequest("DELETE", `/repos/${repo}/issues/comments/${comment.id}`, token)
+      )
+    );
+    return { action: "updated" };
+  }
+
+  await githubRequest("POST", `/repos/${repo}/issues/${issue}/comments`, token, {
+    body,
+  });
+  return { action: "created" };
+}
+
+async function run(argv = process.argv) {
+  const args = parseArgs(argv);
+  if (!args["validation-output"]) {
+    throw new Error("--validation-output is required");
+  }
+
+  const output = fs.readFileSync(args["validation-output"], "utf8");
+  const issues = parseValidationIssues(output);
+  let comments = [];
+  if (args["comments-json"]) {
+    comments = JSON.parse(fs.readFileSync(args["comments-json"], "utf8"));
+  } else if (args.repo && args.issue && process.env.GITHUB_TOKEN) {
+    comments = await listComments(args.repo, args.issue, process.env.GITHUB_TOKEN);
+  }
+
+  const body = buildCommentBody(issues, comments);
+  if (args.output) {
+    if (body) fs.writeFileSync(args.output, `${body}\n`, "utf8");
+    else if (fs.existsSync(args.output)) fs.rmSync(args.output);
+  }
+
+  if (args.dryRun || !args.repo || !args.issue) {
+    if (body) console.log(body);
+    else console.log("No contributor-fixable data validation comment generated.");
+    return;
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN is required to post a comment");
+  const result = await upsertComment(args.repo, args.issue, token, body);
+  console.log(`Data validation PR comment ${result.action}.`);
+}
+
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildCommentBody,
+  marker,
+  parseValidationIssues,
+  upsertComment,
+};

--- a/test/data-validation-pr-comment.js
+++ b/test/data-validation-pr-comment.js
@@ -1,0 +1,264 @@
+const assert = require("node:assert/strict");
+const { afterEach, describe, it } = require("node:test");
+
+const {
+  buildCommentBody,
+  marker,
+  parseValidationIssues,
+  upsertComment,
+} = require("../scripts/data-validation-pr-comment");
+
+const originalFetch = global.fetch;
+
+describe("data-validation-pr-comment", function() {
+  afterEach(function() {
+    global.fetch = originalFetch;
+  });
+
+  it("parses validator issue lines", function() {
+    const issues = parseValidationIssues(
+      [
+        "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
+        "topics.yml should be valid YAML: bad indentation [top-level-yaml-invalid]",
+      ].join("\n")
+    );
+
+    assert.deepEqual(issues, [
+      {
+        path: "packages/com.example.tool.yml",
+        message: "licenseSpdxId must not be an empty string",
+        code: "package-license-spdx-id-empty",
+      },
+      {
+        path: undefined,
+        message: "topics.yml should be valid YAML: bad indentation",
+        code: "top-level-yaml-invalid",
+      },
+    ]);
+  });
+
+  it("builds one contributor-facing comment for common package fixes", function() {
+    const issues = parseValidationIssues(
+      [
+        "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
+        "packages/com.example.tool.yml: topic unknown should be valid [package-topic-invalid]",
+        "packages/com.example.tool.yml: pkg.name should match filename without .yml [package-name-filename-mismatch]",
+        "packages/com.example.tool.yml metadata should be valid: createdAt: Required [package-metadata-invalid]",
+      ].join("\n")
+    );
+
+    const body = buildCommentBody(issues);
+
+    assert.ok(body.includes(marker));
+    assert.ok(body.includes("Fill in `licenseSpdxId`"));
+    assert.ok(body.includes("Use an existing topic slug"));
+    assert.ok(body.includes("Make the filename match `name`"));
+    assert.ok(body.includes("Fix package metadata field `createdAt`"));
+  });
+
+  it("covers every explicitly supported contributor-fixable validator code", function() {
+    const supportedLines = [
+      "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
+      "packages/com.example.tool.yml: licenseSpdxId Nope should be valid [package-license-spdx-id-invalid]",
+      "packages/com.example.tool.yml: licenseName should be MIT License for licenseSpdxId MIT [package-license-name-spdx-mismatch]",
+      "packages/com.example.tool.yml: topic unknown should be valid [package-topic-invalid]",
+      "packages/com.example.tool.yml: com.example.tool is blocked by scope ^com.example. [package-scope-blocked]",
+      "packages/com.example.tool.yml: pkg.name should match filename without .yml [package-name-filename-mismatch]",
+      "packages/com.example.tool.yml: repoUrl is required and must not be empty [package-repo-url-empty]",
+      "packages/com.example.tool.yml: name is required and must not be empty [package-name-empty]",
+      "packages/com.example.tool.yml: licenseName is required and must not be empty [package-license-name-empty]",
+      "packages/com.example.tool.yml: hunter is required and must not be empty [package-hunter-empty]",
+    ];
+
+    const body = buildCommentBody(parseValidationIssues(supportedLines.join("\n")));
+
+    assert.ok(body.includes("Fill in `licenseSpdxId`"));
+    assert.ok(body.includes("Use a valid SPDX license id"));
+    assert.ok(body.includes("Match `licenseName` to `licenseSpdxId`"));
+    assert.ok(body.includes("Use an existing topic slug"));
+    assert.ok(body.includes("Choose a package name outside blocked scopes"));
+    assert.ok(body.includes("Make the filename match `name`"));
+    assert.ok(body.includes("Add `repoUrl`"));
+    assert.ok(body.includes("Add `name`"));
+  });
+
+  it("covers supported metadata schema field guidance", function() {
+    const fields = [
+      "name",
+      "aliases",
+      "repoUrl",
+      "displayName",
+      "description",
+      "licenseSpdxId",
+      "licenseName",
+      "topics",
+      "hunter",
+      "createdAt",
+      "trackingMode",
+    ];
+
+    for (const field of fields) {
+      const body = buildCommentBody(
+        parseValidationIssues(
+          `packages/com.example.tool.yml metadata should be valid: ${field}: Required [package-metadata-invalid]`
+        )
+      );
+
+      assert.ok(body.includes(`Fix package metadata field \`${field}\``));
+    }
+  });
+
+  it("leaves generic CI guidance for ambiguous non-package validation failures", function() {
+    const issues = parseValidationIssues(
+      "blocked-scopes.yml should be valid YAML: bad indentation [top-level-yaml-invalid]"
+    );
+
+    const body = buildCommentBody(issues);
+
+    assert.ok(body.includes("does not have specific guidance"));
+    assert.ok(body.includes("Data validation` CI report"));
+  });
+
+  it("leaves generic CI guidance for unsupported package issue codes", function() {
+    const issues = parseValidationIssues(
+      "packages/com.example.tool.yml: alias com.example.old should not be repeated [package-alias-duplicate]"
+    );
+
+    const body = buildCommentBody(issues);
+
+    assert.ok(body.includes("does not have specific guidance"));
+    assert.ok(body.includes("Data validation` CI report"));
+  });
+
+  it("does not duplicate equivalent human guidance", function() {
+    const issues = parseValidationIssues(
+      "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]"
+    );
+
+    const body = buildCommentBody(issues, [
+      {
+        body: "Please fix licenseSpdxId because it cannot be an empty string.",
+        user: { type: "User" },
+      },
+    ]);
+
+    assert.equal(body, null);
+  });
+
+  it("still comments on distinct fixes when one fix already has human guidance", function() {
+    const issues = parseValidationIssues(
+      [
+        "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
+        "packages/com.example.tool.yml: topic unknown should be valid [package-topic-invalid]",
+      ].join("\n")
+    );
+
+    const body = buildCommentBody(issues, [
+      {
+        body: "Please fix licenseSpdxId because it cannot be an empty string.",
+        user: { type: "User" },
+      },
+    ]);
+
+    assert.ok(body.includes("Use an existing topic slug"));
+    assert.equal(body.includes("Fill in `licenseSpdxId`"), false);
+  });
+
+  it("comments on supported issues and adds generic guidance for unsupported issues in the same run", function() {
+    const issues = parseValidationIssues(
+      [
+        "packages/com.example.tool.yml: alias com.example.old should not be repeated [package-alias-duplicate]",
+        "packages/com.example.tool.yml: topic unknown should be valid [package-topic-invalid]",
+      ].join("\n")
+    );
+
+    const body = buildCommentBody(issues);
+
+    assert.ok(body.includes("Use an existing topic slug"));
+    assert.ok(body.includes("Other validation failure details"));
+    assert.equal(body.includes("alias com.example.old"), false);
+  });
+
+  it("does not treat hunter and repository owner differences as an issue", function() {
+    const issues = parseValidationIssues(
+      "packages/com.example.tool.yml: hunter is required and must not be empty [package-hunter-empty]"
+    );
+
+    const body = buildCommentBody(issues);
+
+    assert.ok(body.includes("Add `hunter`"));
+    assert.ok(body.includes("does not have to match the package repository owner"));
+  });
+
+  it("creates a marker comment when none exists", async function() {
+    const calls = mockFetch([{ response: [] }, { response: { id: 10 } }]);
+
+    const result = await upsertComment("openupm/openupm", 123, "token", `${marker}\nbody`);
+
+    assert.deepEqual(result, { action: "created" });
+    assert.equal(calls[0].method, "GET");
+    assert.equal(calls[1].method, "POST");
+    assert.equal(JSON.parse(calls[1].body).body, `${marker}\nbody`);
+  });
+
+  it("updates one bot marker comment and deletes duplicate bot markers", async function() {
+    const calls = mockFetch([
+      {
+        response: [
+          { id: 1, body: `${marker}\nold`, user: { type: "Bot" } },
+          { id: 2, body: `${marker}\nduplicate`, user: { type: "Bot" } },
+        ],
+      },
+      { response: { id: 1 } },
+      { status: 204, response: null },
+    ]);
+
+    const result = await upsertComment("openupm/openupm", 123, "token", `${marker}\nnew`);
+
+    assert.deepEqual(result, { action: "updated" });
+    assert.equal(calls[1].method, "PATCH");
+    assert.equal(calls[1].url, "https://api.github.com/repos/openupm/openupm/issues/comments/1");
+    assert.equal(calls[2].method, "DELETE");
+    assert.equal(calls[2].url, "https://api.github.com/repos/openupm/openupm/issues/comments/2");
+  });
+
+  it("deletes stale bot marker comments when no supported guidance remains", async function() {
+    const calls = mockFetch([
+      { response: [{ id: 1, body: `${marker}\nold`, user: { type: "Bot" } }] },
+      { status: 204, response: null },
+    ]);
+
+    const result = await upsertComment("openupm/openupm", 123, "token", null);
+
+    assert.deepEqual(result, { action: "deleted" });
+    assert.equal(calls[1].method, "DELETE");
+  });
+
+  it("does not update or delete a human marker comment", async function() {
+    const calls = mockFetch([
+      { response: [{ id: 1, body: `${marker}\nhuman note`, user: { type: "User" } }] },
+      { response: { id: 2 } },
+    ]);
+
+    const result = await upsertComment("openupm/openupm", 123, "token", `${marker}\nnew`);
+
+    assert.deepEqual(result, { action: "created" });
+    assert.equal(calls[1].method, "POST");
+  });
+});
+
+function mockFetch(responses) {
+  const calls = [];
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url, ...options });
+    const next = responses.shift();
+    if (!next) throw new Error(`Unexpected fetch call: ${options.method} ${url}`);
+    return {
+      ok: next.status ? next.status >= 200 && next.status < 300 : true,
+      status: next.status || 200,
+      json: async () => next.response,
+      text: async () => JSON.stringify(next.response),
+    };
+  };
+  return calls;
+}


### PR DESCRIPTION
## Summary
- capture Data validation output so failed PR runs can be analyzed by the workflow
- add a helper that posts or updates one marked GitHub Actions comment for contributor-fixable package metadata failures
- suppress comments for ambiguous/non-package failures and when equivalent human guidance already exists
- include analyzer coverage in the repository test wrapper

## Validation
- npm test
- ran the data-validation comment helper in dry-run mode against sample validator output