### PR TITLE
ci: add generic data validation guidance

### DIFF
--- a/scripts/data-validation-pr-comment.js
+++ b/scripts/data-validation-pr-comment.js
@@ -104,17 +104,43 @@ function parseValidationIssues(output) {
   return output
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .map((line) =>
-      line.match(
-        /^(?:(?<path>packages\/[^:]+|[A-Za-z0-9_.-]+\.ya?ml|packages): )?(?<message>.+) \[(?<code>[a-z0-9-]+)\]$/
-      )
-    )
+    .map(parseValidationIssueLine)
     .filter(Boolean)
-    .map((match) => ({
-      path: match.groups.path,
-      message: match.groups.message,
-      code: match.groups.code,
-    }));
+}
+
+function parseValidationIssueLine(line) {
+  const match = line.match(/^(?<message>.+) \[(?<code>[a-z0-9-]+)\]$/);
+  if (!match) return null;
+
+  const issue = {
+    path: undefined,
+    message: match.groups.message,
+    code: match.groups.code,
+  };
+
+  const metadataMatch = issue.message.match(
+    /^(?<path>packages\/\S+\.yml) metadata should be valid: (?<detail>.+)$/
+  );
+  if (metadataMatch) {
+    return {
+      ...issue,
+      path: metadataMatch.groups.path,
+      message: `metadata should be valid: ${metadataMatch.groups.detail}`,
+    };
+  }
+
+  const pathMatch = issue.message.match(
+    /^(?<path>packages\/\S+|[A-Za-z0-9_.-]+\.ya?ml|packages): (?<detail>.+)$/
+  );
+  if (pathMatch) {
+    return {
+      ...issue,
+      path: pathMatch.groups.path,
+      message: pathMatch.groups.detail,
+    };
+  }
+
+  return issue;
 }
 
 function metadataGuidance(issue) {
@@ -276,7 +302,7 @@ async function run(argv = process.argv) {
 
   if (args.dryRun || !args.repo || !args.issue) {
     if (body) console.log(body);
-    else console.log("No contributor-fixable data validation comment generated.");
+    else console.log("No data validation comment generated.");
     return;
   }
 

--- a/test/data-validation-pr-comment.js
+++ b/test/data-validation-pr-comment.js
@@ -19,6 +19,7 @@ describe("data-validation-pr-comment", function() {
     const issues = parseValidationIssues(
       [
         "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
+        "packages/com.example.tool.yml metadata should be valid: createdAt: Required [package-metadata-invalid]",
         "topics.yml should be valid YAML: bad indentation [top-level-yaml-invalid]",
       ].join("\n")
     );
@@ -28,6 +29,11 @@ describe("data-validation-pr-comment", function() {
         path: "packages/com.example.tool.yml",
         message: "licenseSpdxId must not be an empty string",
         code: "package-license-spdx-id-empty",
+      },
+      {
+        path: "packages/com.example.tool.yml",
+        message: "metadata should be valid: createdAt: Required",
+        code: "package-metadata-invalid",
       },
       {
         path: undefined,


### PR DESCRIPTION
## Summary
- add a generic Data validation CI-report fallback when the analyzer sees an unsupported validation reason
- keep specific guidance for supported package metadata failures and add the generic note for mixed supported/unsupported runs
- fix metadata-invalid parsing so package paths render cleanly in comments

## Validation
- npm test
- dry-ran the comment helper against representative PR validation outputs for #6630, #6589, and #6491
- dry-ran the unsupported-reason fallback path