### PR TITLE
ci: allow multiple added package files

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,12 @@
 pull_request_rules:
   - name: Automatic merge for adding new package
     conditions:
-      - "#files=1"
-      - "files~=data/packages/(.*)\\.yml$"
+      - "#files>=1"
+      - "-files~=^(?!data/packages/[^/]+\\.yml$).*"
       - "-files~=data/packages/(.*)(com\\.amazonaws|com\\.google|com\\.unity|com\\.microsoft|com\\.apple|com\\.meta|com\\.oculus|com\\.twitter)\\.(.*)\\.yml$"
-      - "#added-files=1"
+      - "#added-files>=1"
       - "#modified-files=0"
-      - "#deleted-lines=0"
+      - "#removed-files=0"
       - "author!=tuha263"
       - -conflict
       - "status-success~=Data validation"


### PR DESCRIPTION
## Summary
- allow Mergify auto-merge rule to match multiple added package YAML files
- require every touched file to stay under data/packages/*.yml
- block modified and removed files at the file level

## Validation
- Parsed .mergify.yml as YAML
- Checked the data/packages/*.yml path guard regex with representative paths
- Ran git diff --check