### PR TITLE
ci: add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '20 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    if: github.repository == 'openupm/openupm'
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 7 days if no further
+            activity occurs.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 7 days if no
+            further activity occurs.
+          close-issue-message: >
+            This issue has been automatically closed because it did not have
+            activity after being marked stale.
+          close-pr-message: >
+            This pull request has been automatically closed because it did not
+            have activity after being marked stale.


### PR DESCRIPTION
## Summary
- add a daily actions/stale workflow for issues and pull requests
- mark inactive items stale after 30 days and close them 7 days later if still inactive
- allow manual workflow dispatch for operator runs

## Validation
- Parsed .github/workflows/stale.yml as YAML
- Reviewed workflow inputs and permissions against actions/stale documentation