### PR TITLE
chore(data): new package com.saesentsessis.unity-collections-specialized

### DIFF
--- a/data/packages/com.saesentsessis.unity-collections-specialized.yml
+++ b/data/packages/com.saesentsessis.unity-collections-specialized.yml
@@ -19,3 +19,4 @@ minVersion: 0.1.1
 readme: main:Unity-Collections-Specialized/Assets/root/README.md
 trackingMode: githubRelease
 githubReleaseAssetName: com.saesentsessis.unity-collections-specialized-
+createdAt: 1783116462779

--- a/data/packages/com.saesentsessis.unity-collections-specialized.yml
+++ b/data/packages/com.saesentsessis.unity-collections-specialized.yml
@@ -1,0 +1,21 @@
+name: com.saesentsessis.unity-collections-specialized
+aliases: []
+displayName: Unity Collections Specialized
+description: >-
+  Specialized collection types with stable index handles for Unity.Collections
+  and Burst, including StableIndexList, NativeStableIndexList, and
+  UnsafeStableIndexList.
+repoUrl: https://github.com/Saesentsessis/Unity-Collections-Specialized
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - dots-and-ecs
+hunter: Saesentsessis
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.1
+readme: main:Unity-Collections-Specialized/Assets/root/README.md
+trackingMode: githubRelease
+githubReleaseAssetName: com.saesentsessis.unity-collections-specialized-


### PR DESCRIPTION
Adds the package listing for Unity Collections Specialized — stable-index native collections for Unity.Collections / Burst.

Repo: https://github.com/Saesentsessis/Unity-Collections-Specialized
Tracking mode: githubRelease (signed .tgz attached to GitHub Releases)