### PR TITLE
chore(data): new package com.sinanata.designsystem

### DIFF
--- a/data/packages/com.sinanata.designsystem.yml
+++ b/data/packages/com.sinanata.designsystem.yml
@@ -1,0 +1,25 @@
+name: com.sinanata.designsystem
+aliases: []
+displayName: Design System
+description: >-
+  A drop-in design system for Unity 6 UI Toolkit (UIDocument/PanelRenderer +
+  UXML + USS). Tokens, components, icons, mobile responsiveness, and a runtime
+  helper — all themed dark, all keyboard-and-touch-ready, all editable from one
+  stylesheet.
+repoUrl: https://github.com/sinanata/unity-ui-document-design-system
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: >-
+  https://raw.githubusercontent.com/sinanata/unity-ui-document-design-system/refs/heads/main/docs/screenshots/showcase.png
+topics:
+  - ar-and-vr
+  - gui
+  - mobile
+hunter: sinanata
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1783346042769


### PR DESCRIPTION
Adds the package metadata for `com.sinanata.designsystem` (Unity 6 UI Toolkit design system: tokens, components, icons, mobile responsiveness, runtime helpers; UIDocument + PanelRenderer backends).

- Repo: https://github.com/sinanata/unity-ui-document-design-system
- Package folder: `Assets/DesignSystem` (package.json version 1.4.3)
- Release tag: `v1.4.3`
- License: MIT

YAML content is exactly what the openupm.com submission form generated; opening the PR manually because the form's "Fork this repository" step errored on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)