### PR TITLE
chore(data): new package com.hashiiiii.prefablens

### DIFF
--- a/data/packages/com.hashiiiii.prefablens.yml
+++ b/data/packages/com.hashiiiii.prefablens.yml
@@ -1,0 +1,22 @@
+name: com.hashiiiii.prefablens
+aliases: []
+displayName: PrefabLens
+description: >-
+  Semantic diff for UnityYAML assets in the Unity Editor. Shows prefab and
+  scene changes at the GameObject, component, and field level instead of raw
+  text diffs.
+repoUrl: https://github.com/hashiiiii/PrefabLens
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: ''
+topics:
+  - version-control
+  - editor-enhancement
+hunter: hashiiiii
+gitTagPrefix: 'v'
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1783960436000


### PR DESCRIPTION
## Summary

Add `com.hashiiiii.prefablens` — semantic diff for UnityYAML assets in the Unity Editor. Shows prefab and scene changes at the GameObject, component, and field level instead of raw text diffs.

## Motivation

Distribute the package to Unity developers via OpenUPM.

## Changes

- Add `data/packages/com.hashiiiii.prefablens.yml`

## Testing

- Repository: https://github.com/hashiiiii/PrefabLens (Apache-2.0, hosted on GitHub)
- The UPM package lives in the `editor/` subfolder; `package.json` version is stamped per release and matches every `vX.Y.Z` tag (v0.1.0 through v0.6.1)