### PR TITLE
com.jelewow.unity-sheets-localization: githubRelease

### DIFF
--- a/data/packages/com.jelewow.unity-sheets-localization.yml
+++ b/data/packages/com.jelewow.unity-sheets-localization.yml
@@ -8,7 +8,7 @@ description: >-
   service-account authentication and a pluggable, ScriptableObject-based parsing
   pipeline.
 repoUrl: https://github.com/Jelewow/unity-google-localization
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -22,3 +22,4 @@ gitTagIgnore: ''
 minVersion: ''
 readme: main:README.md
 createdAt: 1784033920756
+


### PR DESCRIPTION
Switch to githubRelease before publishing signed v1.0.2 from GitHub Release assets.