### PR TITLE
feat: add com.directinput.unity

### DIFF
--- a/data/packages/com.directinput.unity.yml
+++ b/data/packages/com.directinput.unity.yml
@@ -6,7 +6,7 @@ repoUrl: https://github.com/imDanoush/Unity-DirectInput
 trackingMode: git
 parentRepoUrl: https://github.com/ATG-Simulator/Unity-DirectInput
 licenseSpdxId: LGPL-3.0
-licenseName: GNU Lesser General Public License v3.0
+licenseName: GNU Lesser General Public License v3.0 only
 image: ''
 topics:
   - input-management

--- a/data/packages/com.directinput.unity.yml
+++ b/data/packages/com.directinput.unity.yml
@@ -1,0 +1,19 @@
+name: com.directinput.unity
+aliases: []
+displayName: DirectInput
+description: A native DirectInput plugin to expose DirectX Input & ForceFeedback for Unity
+repoUrl: https://github.com/imDanoush/Unity-DirectInput
+trackingMode: git
+parentRepoUrl: https://github.com/ATG-Simulator/Unity-DirectInput
+licenseSpdxId: LGPL-3.0
+licenseName: GNU Lesser General Public License v3.0
+image: ''
+topics:
+  - input-management
+  - integration
+hunter: imDanoush
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 1.1.1
+readme: main:README.md
+createdAt: 1784486950356


### PR DESCRIPTION
Adds com.directinput.unity (Unity-DirectInput) to the OpenUPM registry.

- Repository: https://github.com/imDanoush/Unity-DirectInput
- Package name: com.directinput.unity
- Current version tag: 1.1.1
- License: GNU Lesser General Public License v3.0

Unity-DirectInput exposes DirectX DirectInput and ForceFeedback APIs to Unity, and is used as an optional dependency by third-party assets such as NWH Vehicle Physics 2.