### PR TITLE
chore(data): add com.plumvery.unilfs

### DIFF
--- a/data/packages/com.plumvery.unilfs.yml
+++ b/data/packages/com.plumvery.unilfs.yml
@@ -1,0 +1,16 @@
+name: com.plumvery.unilfs
+displayName: UniLFS
+description: Store large Unity assets in your own external storage (Cloudflare R2 / any S3-compatible service / Google Drive) instead of Git LFS. Tracked files are gitignored and restored from a committed SHA-256 manifest.
+repoUrl: 'https://github.com/Plumvery/UniLFS'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - utilities
+hunter: Plumvery
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'main:README.md'
+createdAt: 1784645572000

--- a/data/packages/com.plumvery.unilfs.yml
+++ b/data/packages/com.plumvery.unilfs.yml
@@ -1,16 +1,19 @@
 name: com.plumvery.unilfs
+aliases: []
 displayName: UniLFS
 description: Store large Unity assets in your own external storage (Cloudflare R2 / any S3-compatible service / Google Drive) instead of Git LFS. Tracked files are gitignored and restored from a committed SHA-256 manifest.
-repoUrl: 'https://github.com/Plumvery/UniLFS'
+repoUrl: https://github.com/Plumvery/UniLFS
+trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
+image: ''
 topics:
+  - editor-enhancement
   - utilities
 hunter: Plumvery
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
-image: null
-readme: 'main:README.md'
-createdAt: 1784645572000
+minVersion: 0.1.0
+readme: main:README.md
+createdAt: 1784648655000


### PR DESCRIPTION
Adds **UniLFS** — a Unity editor package that stores large assets in the user's own external storage (Cloudflare R2 / any S3-compatible service / Google Drive) instead of Git LFS. Tracked files are gitignored automatically and restored from a committed SHA-256 manifest.

- Repository: https://github.com/Plumvery/UniLFS
- License: MIT
- UPM `package.json` at repo root, semver git tags (`v0.1.0`, `v0.2.0`)

I am the author of the package.