### PR TITLE
fix(data): replace plain GitHub blob image URLs

### DIFF
--- a/data/packages/com.alicizax.unity.animationflow.yml
+++ b/data/packages/com.alicizax.unity.animationflow.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 image: >-
-  https://github.com/AlicizaX/public-github-actions-Public/blob/main/238003343.png
+  https://raw.githubusercontent.com/AlicizaX/public-github-actions-Public/main/238003343.png
 topics:
   - frameworks
 hunter: AlicizaX

--- a/data/packages/com.alicizax.unity.cysharp.unitask.yml
+++ b/data/packages/com.alicizax.unity.cysharp.unitask.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 image: >-
-  https://github.com/AlicizaX/public-github-actions-Public/blob/main/238003343.png
+  https://raw.githubusercontent.com/AlicizaX/public-github-actions-Public/main/238003343.png
 topics:
   - frameworks
 hunter: AlicizaX

--- a/data/packages/com.alicizax.unity.debugger.yml
+++ b/data/packages/com.alicizax.unity.debugger.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 image: >-
-  https://github.com/AlicizaX/public-github-actions-Public/blob/main/238003343.png
+  https://raw.githubusercontent.com/AlicizaX/public-github-actions-Public/main/238003343.png
 topics:
   - frameworks
 hunter: AlicizaX

--- a/data/packages/com.alicizax.unity.editor.extension.yml
+++ b/data/packages/com.alicizax.unity.editor.extension.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 image: >-
-  https://github.com/AlicizaX/public-github-actions-Public/blob/main/238003343.png
+  https://raw.githubusercontent.com/AlicizaX/public-github-actions-Public/main/238003343.png
 topics:
   - frameworks
 hunter: AlicizaX

--- a/data/packages/com.alicizax.unity.framework.yml
+++ b/data/packages/com.alicizax.unity.framework.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 image: >-
-  https://github.com/AlicizaX/public-github-actions-Public/blob/main/238003343.png
+  https://raw.githubusercontent.com/AlicizaX/public-github-actions-Public/main/238003343.png
 topics:
   - frameworks
 hunter: AlicizaX

--- a/data/packages/com.alicizax.unity.ui.extension.yml
+++ b/data/packages/com.alicizax.unity.ui.extension.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0
 image: >-
-  https://github.com/AlicizaX/public-github-actions-Public/blob/main/238003343.png
+  https://raw.githubusercontent.com/AlicizaX/public-github-actions-Public/main/238003343.png
 topics:
   - frameworks
 hunter: AlicizaX

--- a/data/packages/com.cr7sund.tweentimeline.yml
+++ b/data/packages/com.cr7sund.tweentimeline.yml
@@ -8,7 +8,7 @@ trackingMode: git
 parentRepoUrl: null
 licenseName: MIT License
 licenseSpdxId: MIT
-image: https://github.com/liuxinjia/TweenTimeline/blob/master/Document/LogoBanner.png
+image: https://raw.githubusercontent.com/liuxinjia/TweenTimeline/master/Document/LogoBanner.png
 topics:
 - animation
 - code-generation

--- a/data/packages/com.cwj.unitydevtool.yml
+++ b/data/packages/com.cwj.unitydevtool.yml
@@ -10,7 +10,7 @@ parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 image: >-
-  https://github.com/DevCWJ/cwj.unitydevtool/blob/main/Runtime/CWJ/UnityDevTool/Icon/CWJ.png
+  https://raw.githubusercontent.com/DevCWJ/cwj.unitydevtool/main/Runtime/CWJ/UnityDevTool/Icon/CWJ.png
 topics:
   - code-generation
   - editor-enhancement

--- a/data/packages/com.greenbamboogames.assetchecker.yml
+++ b/data/packages/com.greenbamboogames.assetchecker.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
 image: >-
-  https://github.com/SolarianZ/UnityAssetChecker/blob/main/Documents~/imgs/img_sample_asset_checker_window.png
+  https://raw.githubusercontent.com/SolarianZ/UnityAssetChecker/main/Documents~/imgs/img_sample_asset_checker_window.png
 topics:
   - asset-management
   - data-management

--- a/data/packages/com.heavycavstudios.core.yml
+++ b/data/packages/com.heavycavstudios.core.yml
@@ -8,7 +8,7 @@ parentRepoUrl: null
 licenseName: MIT License
 licenseSpdxId: MIT
 image: >-
-  https://github.com/Heavy-Cav-Studios/Core/blob/Core-first-version/core-icon.png
+  https://raw.githubusercontent.com/Heavy-Cav-Studios/Core/Core-first-version/core-icon.png
 topics:
   - utilities
 hunter: DeathAdder1999

--- a/data/packages/com.v0lt.editor-attributes.yml
+++ b/data/packages/com.v0lt.editor-attributes.yml
@@ -11,7 +11,7 @@ parentRepoUrl: null
 licenseSpdxId: Unlicense
 licenseName: The Unlicense
 image: >-
-  https://github.com/v0lt13/EditorAttributes/blob/main/Samples~/EditorAttributesIcon.png
+  https://raw.githubusercontent.com/v0lt13/EditorAttributes/main/Samples~/EditorAttributesIcon.png
 topics:
   - editor-enhancement
 hunter: ThisSome1

--- a/data/packages/com.virgis.core.yml
+++ b/data/packages/com.virgis.core.yml
@@ -15,7 +15,7 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: 2.1.5
 image: >-
-  https://github.com/ViRGIS-Team/virgis.org/blob/raw/images/virgis_swallow_72.png
+  https://raw.githubusercontent.com/ViRGIS-Team/virgis.org/raw/images/virgis_swallow_72.png
 readme: 'version_2:README.md'
 readme_zhCN: ''
 displayName_zhCN: ''

--- a/scripts/data-validation-pr-comment.js
+++ b/scripts/data-validation-pr-comment.js
@@ -62,6 +62,12 @@ const fixableIssues = {
       "`hunter` is required and should be the GitHub user who submitted or maintains the package metadata. It does not have to match the package repository owner.",
     duplicateTerms: ["hunter"],
   },
+  "package-image-github-blob-url-invalid": {
+    title: "Use a raw GitHub image URL",
+    guidance:
+      "A plain `github.com/.../blob/...` URL points to a GitHub HTML page instead of image bytes. Use `raw.githubusercontent.com`, a GitHub `/raw/` URL, or add `?raw=true` to the blob URL.",
+    duplicateTerms: ["github.com", "blob", "raw"],
+  },
 };
 
 const metadataRequiredFields = [

--- a/test/data-validation-pr-comment.js
+++ b/test/data-validation-pr-comment.js
@@ -118,30 +118,68 @@ describe("data-validation-pr-comment", function() {
   });
 
   it("covers every explicitly supported contributor-fixable validator code", function() {
-    const supportedLines = [
-      "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
-      "packages/com.example.tool.yml: licenseSpdxId Nope should be valid [package-license-spdx-id-invalid]",
-      "packages/com.example.tool.yml: licenseName should be MIT License for licenseSpdxId MIT [package-license-name-spdx-mismatch]",
-      "packages/com.example.tool.yml: topic unknown should be valid [package-topic-invalid]",
-      "packages/com.example.tool.yml: com.example.tool is blocked by scope ^com.example. [package-scope-blocked]",
-      "packages/com.example.tool.yml: pkg.name should match filename without .yml [package-name-filename-mismatch]",
-      "packages/com.example.tool.yml: repoUrl is required and must not be empty [package-repo-url-empty]",
-      "packages/com.example.tool.yml: name is required and must not be empty [package-name-empty]",
-      "packages/com.example.tool.yml: licenseName is required and must not be empty [package-license-name-empty]",
-      "packages/com.example.tool.yml: hunter is required and must not be empty [package-hunter-empty]",
+    const supportedIssues = [
+      [
+        "packages/com.example.tool.yml: image field must not use a plain github.com blob URL [package-image-github-blob-url-invalid]",
+        "Use a raw GitHub image URL",
+      ],
+      [
+        "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
+        "Fill in `licenseSpdxId`",
+      ],
+      [
+        "packages/com.example.tool.yml: licenseSpdxId Nope should be valid [package-license-spdx-id-invalid]",
+        "Use a valid SPDX license ID",
+      ],
+      [
+        "packages/com.example.tool.yml: licenseName should be MIT License for licenseSpdxId MIT [package-license-name-spdx-mismatch]",
+        "Match `licenseName` to `licenseSpdxId`",
+      ],
+      [
+        "packages/com.example.tool.yml: topic unknown should be valid [package-topic-invalid]",
+        "Use an existing topic slug",
+      ],
+      [
+        "packages/com.example.tool.yml: com.example.tool is blocked by scope ^com.example. [package-scope-blocked]",
+        "Choose a package name outside blocked scopes",
+      ],
+      [
+        "packages/com.example.tool.yml: pkg.name should match filename without .yml [package-name-filename-mismatch]",
+        "Make the filename match `name`",
+      ],
+      [
+        "packages/com.example.tool.yml: repoUrl is required and must not be empty [package-repo-url-empty]",
+        "Add `repoUrl`",
+      ],
+      [
+        "packages/com.example.tool.yml: name is required and must not be empty [package-name-empty]",
+        "Add `name`",
+      ],
+      [
+        "packages/com.example.tool.yml: licenseName is required and must not be empty [package-license-name-empty]",
+        "Add `licenseName`",
+      ],
+      [
+        "packages/com.example.tool.yml: hunter is required and must not be empty [package-hunter-empty]",
+        "Add `hunter`",
+      ],
     ];
 
-    const body = buildCommentBody(parseValidationIssues(supportedLines.join("\n")));
+    for (const [line, title] of supportedIssues) {
+      const body = buildCommentBody(parseValidationIssues(line));
+      assert.ok(body.includes(title));
+    }
+  });
 
-    assert.ok(body.includes("Fill in `licenseSpdxId`"));
-    assert.ok(body.includes("Use a valid SPDX license ID"));
-    assert.ok(body.includes("Match `licenseName` to `licenseSpdxId`"));
-    assert.ok(body.includes("https://spdx.org/licenses/"));
-    assert.ok(body.includes("Use an existing topic slug"));
-    assert.ok(body.includes("Choose a package name outside blocked scopes"));
-    assert.ok(body.includes("Make the filename match `name`"));
-    assert.ok(body.includes("Add `repoUrl`"));
-    assert.ok(body.includes("Add `name`"));
+  it("guides contributors away from plain GitHub blob image URLs", function() {
+    const body = buildCommentBody(
+      parseValidationIssues(
+        "packages/com.example.tool.yml: image field must not use a plain github.com blob URL [package-image-github-blob-url-invalid]"
+      )
+    );
+
+    assert.ok(body.includes("Use a raw GitHub image URL"));
+    assert.ok(body.includes("raw.githubusercontent.com"));
   });
 
   it("covers supported metadata schema field guidance", function() {


### PR DESCRIPTION
## Summary\n- replace all existing plain GitHub blob-page image URLs with raw-content URLs\n- add CI contributor guidance for rejected plain blob image URLs\n\n## Validation\n- npm test with the updated local data validator\n- confirmed no plain github.com blob image URLs remain