### PR TITLE
com.mygamedevtools.scene-loader: switch to signed githubRelease tracking

### DIFF
--- a/data/packages/com.mygamedevtools.scene-loader.yml
+++ b/data/packages/com.mygamedevtools.scene-loader.yml
@@ -4,7 +4,8 @@ displayName: Advanced Scene Manager
 description: >-
   Enhance your scene loading experience in Unity.
 repoUrl: 'https://github.com/mygamedevtools/scene-loader'
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: 'com.mygamedevtools.scene-loader-'
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License
@@ -15,7 +16,7 @@ topics:
 hunter: joaoborks
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: 1.2.0
+minVersion: 4.1.2
 image: ''
 readme: 'main:README.md'
 readme_zhCN: ''


### PR DESCRIPTION
Switches `com.mygamedevtools.scene-loader` to signed `githubRelease` tracking, following the [signing guide](https://openupm.com/docs/signing-upm-packages) and openupm/openupm#6402.

**Changes**

- `trackingMode: git` → `githubRelease`
- `githubReleaseAssetName: 'com.mygamedevtools.scene-loader-'` — releases also carry a `.unitypackage` asset, so the prefix pins selection to the signed tarball
- `minVersion: 1.2.0` → `4.1.2`

**On `minVersion`**

Releases back to 4.0.0 already have unsigned `.tgz` assets attached (they predate signing and were published under git tracking). Raising the floor to 4.1.2 makes sure only signed tarballs are ever tracked going forward. Versions ≤ 4.1.1 stay published as-is.

4.1.2 will be the first signed release — it isn't cut yet. Per the note in openupm/openupm#6402 about avoiding the race, I'm landing this metadata change before bumping the version.

**Signing setup**

Signed with Unity's standalone UPM CLI (`upm pack --organization-id`) in GitHub Actions, using a Unity Cloud service account with the Package Manager Package Signer role. The workflow verifies `package/package.json` and `package/.attestation.p7m` are present in the tarball before uploading it to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
