### PR TITLE
com.mygamedevtools.scene-loader: ignore upm/ subtree tags

### DIFF
--- a/data/packages/com.mygamedevtools.scene-loader.yml
+++ b/data/packages/com.mygamedevtools.scene-loader.yml
@@ -15,7 +15,7 @@ topics:
   - utilities
 hunter: joaoborks
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: '^upm/'
 minVersion: 4.1.2
 image: ''
 readme: 'main:README.md'


### PR DESCRIPTION
Follow-up to #6726, which switched this package to `trackingMode: githubRelease`.

The `4.1.2` build failed with a missing release asset, and the API entry shows why:

```json
{ "tag": "upm/4.1.2", "version": "4.1.2", "source": "githubRelease",
  "state": 3, "reason": 904, "buildId": "",
  "githubReleaseAssetMissingProbeCount": 3 }
```

with `"invalidTags": ["4.1.2"]` alongside it.

The repo pushes two tags per release: `4.1.2` (carries the GitHub Release and the signed `com.mygamedevtools.scene-loader-4.1.2.tgz`) and `upm/4.1.2`, a `git subtree split` tag pointing at the packaged branch. Both resolve to version `4.1.2`, so the `upm/` one won the dedupe and the tag holding the actual release was discarded as invalid. No GitHub Release is attached to `upm/4.1.2`, so the asset probe found nothing.

Ignoring the subtree tags leaves `4.1.2` as the only candidate, which is the tag that has both the release and the signed asset. The `upm/*` tags are kept in the repo because they are used for pinned git-URL installs.

Verified the regex against real tag names — it matches `upm/4.1.2` and `upm/4.1.2-pre.5`, and leaves `4.1.2` / `4.1.2-pre.5` alone.
