### PR TITLE
chore(data): point ReactUnity packages at the core monorepo

### DIFF
--- a/data/packages/com.reactunity.clearscript.yml
+++ b/data/packages/com.reactunity.clearscript.yml
@@ -2,7 +2,7 @@ name: com.reactunity.clearscript
 aliases: []
 displayName: React Unity ClearScript
 description: ClearScript (V8) Plugin for ReactUnity
-repoUrl: 'https://github.com/ReactUnity/clearscript'
+repoUrl: 'https://github.com/ReactUnity/core'
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
@@ -11,11 +11,11 @@ topics:
   - frameworks
   - gui
 hunter: KurtGokhan
-gitTagPrefix: ''
+gitTagPrefix: 'upm/clearscript/'
 gitTagIgnore: ''
 minVersion: ''
 image: 'https://avatars2.githubusercontent.com/u/62178684'
-readme: 'main:README.md'
+readme: 'main:unity/clearscript/README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''

--- a/data/packages/com.reactunity.core.yml
+++ b/data/packages/com.reactunity.core.yml
@@ -13,10 +13,10 @@ topics:
   - gui
 hunter: KurtGokhan
 gitTagPrefix: ''
-gitTagIgnore: ''
+gitTagIgnore: '/'
 minVersion: 0.0.13
 image: 'https://avatars2.githubusercontent.com/u/62178684'
-readme: 'main:README.md'
+readme: 'main:unity/core/README.md'
 createdAt: 1584361495094
 displayName_zhCN: React Unity
 description_zhCN: 用于在Unity UI中构建用户界面的React渲染器

--- a/data/packages/com.reactunity.jint.yml
+++ b/data/packages/com.reactunity.jint.yml
@@ -2,7 +2,7 @@ name: com.reactunity.jint
 aliases: []
 displayName: React Unity Jint
 description: Jint Plugin for ReactUnity
-repoUrl: 'https://github.com/ReactUnity/jint'
+repoUrl: 'https://github.com/ReactUnity/core'
 trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
@@ -11,11 +11,11 @@ topics:
   - frameworks
   - gui
 hunter: KurtGokhan
-gitTagPrefix: ''
+gitTagPrefix: 'upm/jint/'
 gitTagIgnore: ''
 minVersion: ''
 image: 'https://avatars2.githubusercontent.com/u/62178684'
-readme: 'main:README.md'
+readme: 'main:unity/jint/README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''

--- a/data/packages/com.reactunity.quickjs.yml
+++ b/data/packages/com.reactunity.quickjs.yml
@@ -2,7 +2,7 @@ name: com.reactunity.quickjs
 aliases: []
 displayName: React Unity QuickJS
 description: QuickJS Plugin for ReactUnity
-repoUrl: 'https://github.com/ReactUnity/quickjs'
+repoUrl: 'https://github.com/ReactUnity/core'
 trackingMode: git
 parentRepoUrl: 'https://github.com/ialex32x/unity-jsb'
 licenseSpdxId: MIT
@@ -11,11 +11,11 @@ topics:
   - frameworks
   - gui
 hunter: KurtGokhan
-gitTagPrefix: ''
+gitTagPrefix: 'upm/quickjs/'
 gitTagIgnore: ''
 minVersion: ''
 image: 'https://avatars2.githubusercontent.com/u/62178684'
-readme: 'main:README.md'
+readme: 'main:unity/quickjs/README.md'
 readme_zhCN: ''
 displayName_zhCN: ''
 description_zhCN: ''


### PR DESCRIPTION
ReactUnity has consolidated its repositories into a single monorepo at
[ReactUnity/core](https://github.com/ReactUnity/core). `com.reactunity.jint`, `.quickjs`
and `.clearscript` no longer have repositories of their own, and `com.reactunity.core`'s
package now lives at `unity/core/` rather than at the repository root.

Package names are unchanged and no published version is affected — this is a `repoUrl` /
tag-family update per
[Modifying the Package Metadata YAML File](https://openupm.com/docs/modifying-upm-package.html#modifying-the-package-metadata-yaml-file).

| package | repoUrl | gitTagPrefix | gitTagIgnore | readme |
| --- | --- | --- | --- | --- |
| `com.reactunity.core` | unchanged | `''` | `''` → `'/'` | → `main:unity/core/README.md` |
| `com.reactunity.jint` | `…/jint` → `…/core` | → `upm/jint/` | unchanged | → `main:unity/jint/README.md` |
| `com.reactunity.quickjs` | `…/quickjs` → `…/core` | → `upm/quickjs/` | unchanged | → `main:unity/quickjs/README.md` |
| `com.reactunity.clearscript` | `…/clearscript` → `…/core` | → `upm/clearscript/` | unchanged | → `main:unity/clearscript/README.md` |
