### PR TITLE
chore(data): complete Praenaris package renames

### DIFF
--- a/data/packages/com.praenaris.devkit.yml
+++ b/data/packages/com.praenaris.devkit.yml
@@ -1,5 +1,6 @@
 name: com.praenaris.devkit
-aliases: []
+aliases:
+  - com.dragonresonance.devkit
 displayName: Praenaris DevKit
 description: ''
 repoUrl: https://github.com/Praenaris/Unity-DevKit
@@ -31,6 +32,6 @@ topics:
 hunter: davidtabernerom
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: 3.12.4
 readme: master:README.md
 createdAt: 1766449377474

--- a/data/packages/com.praenaris.toolset.yml
+++ b/data/packages/com.praenaris.toolset.yml
@@ -1,5 +1,6 @@
 name: com.praenaris.toolset
-aliases: []
+aliases:
+  - com.dragonresonance.toolset
 displayName: Praenaris ToolSet
 description: ''
 repoUrl: https://github.com/Praenaris/Unity-ToolSet
@@ -31,6 +32,6 @@ topics:
 hunter: davidtabernerom
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: 3.6.6
 readme: master:README.md
 createdAt: 1766449375614


### PR DESCRIPTION
## Summary
- add `com.dragonresonance.devkit` as an alias of `com.praenaris.devkit`
- add `com.dragonresonance.toolset` as an alias of `com.praenaris.toolset`
- set `minVersion` to the anticipated next patch releases, `3.12.4` and `3.6.6`

## Why
PRs #6738 and #6739 renamed the package manifests but left `aliases` and `minVersion` unset. The version floors exclude the latest old-name tags (`v3.12.3` and `v3.6.5`) and prepare tracking for the first renamed releases.

## Validation
- `npm test` (20 tests passed)
- `git diff --check`
- independent complete-branch review against current `master`: clean