### PR TITLE
Add package com.txcombo.unity-git-worktree-label

### DIFF
--- a/data/packages/com.txcombo.unity-git-worktree-label.yml
+++ b/data/packages/com.txcombo.unity-git-worktree-label.yml
@@ -1,0 +1,20 @@
+name: com.txcombo.unity-git-worktree-label
+aliases: []
+displayName: Unity Git Worktree Label
+description: >-
+  Unity Editor toolbar button that identifies the current git worktree/branch,
+  so multiple parallel Editor instances are easy to tell apart.
+repoUrl: https://github.com/hwei/unity-git-worktree-label
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - editor-enhancement
+hunter: hwei
+gitTagPrefix: upm/
+gitTagIgnore: ''
+minVersion: ''
+readme: upm:README.md
+createdAt: 1785315443457

--- a/data/packages/com.txcombo.unity-git-worktree-label.yml
+++ b/data/packages/com.txcombo.unity-git-worktree-label.yml
@@ -12,9 +12,10 @@ licenseName: MIT License
 image: ''
 topics:
   - editor-enhancement
+  - version-control
 hunter: hwei
 gitTagPrefix: upm/
 gitTagIgnore: ''
 minVersion: ''
-readme: upm:README.md
+readme: main:README.md
 createdAt: 1785315443457


### PR DESCRIPTION
## Package

- Name: `com.txcombo.unity-git-worktree-label`
- Repo: https://github.com/hwei/unity-git-worktree-label
- Description: Unity Editor toolbar button that identifies the current git worktree/branch, so multiple parallel Editor instances are easy to tell apart.
- License: MIT
- Tracking mode: git tag checkout, tag prefix `upm/` (a GitHub Action builds the package on each `vX.Y.Z` tag and publishes it to the `upm` branch with a matching `upm/vX.Y.Z` tag)