### PR TITLE
chore(data): add missing hunters for asyns packages

### DIFF
--- a/data/packages/com.asynsstudio.hometween.yml
+++ b/data/packages/com.asynsstudio.hometween.yml
@@ -7,6 +7,7 @@ licenseName: MIT License
 topics:
   - animation
   - utilities
+hunter: asyns
 trackingMode: git
 aliases: []
 createdAt: 1775059200000

--- a/data/packages/com.asynsstudio.homeui.yml
+++ b/data/packages/com.asynsstudio.homeui.yml
@@ -6,6 +6,7 @@ licenseSpdxId: MIT
 licenseName: MIT License
 topics:
   - gui
+hunter: asyns
 trackingMode: git
 aliases: []
 createdAt: 1775059200000


### PR DESCRIPTION
## Summary

- add `hunter: asyns` to `com.asynsstudio.hometween`
- add `hunter: asyns` to `com.asynsstudio.homeui`
- repair the only two active package manifests found with an omitted `hunter` key

The value is backed by both the package submission author and repository owner.

## Validation

- `OPENUPM_NEXT_PATH=<openupm-next-worktree> npm test`
- full OpenUPM data scan with the updated shared validator
- full VuePress website build against the repaired data (6,193 pages)
- independent branch review: clean