### PR TITLE
chore(data): add com.luci0n.crowfx

### DIFF
--- a/data/packages/com.luci0n.crowfx.yml
+++ b/data/packages/com.luci0n.crowfx.yml
@@ -1,0 +1,20 @@
+name: com.luci0n.crowfx
+aliases: []
+displayName: CrowFX
+description: Free CRT, VHS, film, glitch, dithering, and retro post-processing for Unity Built-in, URP, and HDRP.
+repoUrl: https://github.com/Luci0n/CrowFX-Unity-Image-Effects
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: https://raw.githubusercontent.com/Luci0n/CrowFX-Unity-Image-Effects/main/Documentation/Images/crowfx-inspector-top.png
+topics:
+  - camera
+  - particles-and-effects
+  - video
+hunter: Luci0n
+gitTagPrefix: v
+gitTagIgnore: ''
+minVersion: ''
+readme: main:README.md
+createdAt: 1785720863548


### PR DESCRIPTION
﻿## Summary

Adds CrowFX (`com.luci0n.crowfx`) to the OpenUPM package registry.

- Repository: https://github.com/Luci0n/CrowFX-Unity-Image-Effects
- Tracking: Git tags with the `v` prefix
- License: MIT
- Package location: `CrowFX/package.json`
- Topics: camera, particles-and-effects, video

## Validation

- Parsed the YAML and verified required metadata fields.
- Confirmed `v2.0.0` contains `com.luci0n.crowfx` version `2.0.0`.
- Confirmed the MIT license and raw preview image are reachable.
- `git diff --check` passes.
- Independent branch review passed with no actionable findings.
- 19 repository tests pass locally. Full data validation requires the separately built sibling `openupm-next` validator and is deferred to CI.
