### PR TITLE
Create com.google.ads.mobile.mediation.verve.yml

### DIFF
--- a/data/packages/com.google.ads.mobile.mediation.verve.yml
+++ b/data/packages/com.google.ads.mobile.mediation.verve.yml
@@ -1,0 +1,22 @@
+name: com.google.ads.mobile.mediation.verve
+aliases: []
+displayName: Google Mobile Ads Verve Mediation
+description: >-
+  The Google Mobile Ads mediation plugin for Verve package allows you to load and
+  display ads from Verve using mediation, covering waterfall integrations.
+repoUrl: https://github.com/googleads/googleads-mobile-unity-mediation
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: >-
+  https://lh3.googleusercontent.com/D71NOtwLFHvG8WfOO2fmSUTmbhT6ezmC0--7Si2A1BDjTSVcp6fJgAa4H-aVz-sZ2a7tcoXc7f_HBGq27lctq7mrqaOJD7tcfR_lOQ=w770-h734-p-nu-pa
+topics:
+  - integration
+  - mobile
+  - services
+hunter: googleads
+gitTagPrefix: 'Verve/'
+gitTagIgnore: ''
+minVersion: ''
+readme: main:Verve/README.md
+createdAt: 1722989535000

--- a/data/packages/com.google.ads.mobile.mediation.verve.yml
+++ b/data/packages/com.google.ads.mobile.mediation.verve.yml
@@ -18,5 +18,6 @@ hunter: googleads
 gitTagPrefix: 'Verve/'
 gitTagIgnore: ''
 minVersion: ''
+trackingMode: git
 readme: main:Verve/README.md
 createdAt: 1722989535000


### PR DESCRIPTION
The Google Mobile Ads mediation plugin for Verve package allows you to load and display ads from Verve using mediation, covering bidding integrations.