### PR TITLE
Create com.takayama.audiometadataextension.yml

### DIFF
--- a/data/packages/com.takayama.audiometadataextension.yml
+++ b/data/packages/com.takayama.audiometadataextension.yml
@@ -1,0 +1,20 @@
+name: com.takayama.audiometadataextension
+aliases: []
+displayName: Audio Metadata Extension
+description: >-
+  Audio Metadata Extractor is a project which intend to extract metadata of audio file using TagLib and parse it to game engine using Native Binding.
+repoUrl: 'https://github.com/ProjectGrinder/audio-metadata-extractor'
+trackingMode: releaseAsset
+releaseAssetName: com.takayama.audiometadataextension
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: 'https://raw.githubusercontent.com/ProjectGrinder/audio-metadata-extractor/main/icon.png'
+topics:
+  - audio
+  - utilities
+hunter: ProjectGrinder
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+readme: 'main:README.md'

--- a/data/packages/com.takayama.audiometadataextension.yml
+++ b/data/packages/com.takayama.audiometadataextension.yml
@@ -4,7 +4,7 @@ displayName: Audio Metadata Extension
 description: >-
   Audio Metadata Extractor is a project which intend to extract metadata of audio file using TagLib and parse it to game engine using Native Binding.
 repoUrl: 'https://github.com/ProjectGrinder/audio-metadata-extractor'
-trackingMode: releaseAsset
+trackingMode: githubRelease
 releaseAssetName: com.takayama.audiometadataextension
 parentRepoUrl: null
 licenseSpdxId: MIT
@@ -18,3 +18,4 @@ gitTagPrefix: ''
 gitTagIgnore: ''
 minVersion: ''
 readme: 'main:README.md'
+createdAt: 1788890000000


### PR DESCRIPTION
## New Package

**Package Name:** `com.takayama.audiometadataextension`
**Display Name:** Audio Metadata Extension
**Repository:** https://github.com/ProjectGrinder/audio-metadata-extractor
**License:** MIT
**Unity:** 6000.0+

### Description

Audio Metadata Extractor is a project which intend to extract metadata of audio file using TagLib and parse it to game engine using Native Binding.

### Checklist

- [x] Package name follows reverse domain convention
- [x] Repository is public
- [x] License is open source (MIT)
- [x] package.json exists at `binding/unity/package.json`
- [x] Git tags follow semver (`v2.0.0`)
- [x] Repository has releases