### PR TITLE
Create ai.localkeep.unity.yml 

### DIFF
--- a/data/packages/ai.localkeep.unity.yml
+++ b/data/packages/ai.localkeep.unity.yml
@@ -1,0 +1,21 @@
+name: ai.localkeep.unity
+aliases: []
+displayName: Local Keep AI
+description: >-
+  Local-first AI coding assistant for the Unity Editor — explain C# scripts,
+  generate NUnit tests, and run agentic tasks against 1,000+ free models.
+  Requires the lk CLI (pip install local-keep-ai-cli).
+repoUrl: https://github.com/laynef/localkeep-unity
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: https://raw.githubusercontent.com/laynef/localkeep-unity/main/cover.png
+topics:
+  - ai
+hunter: laynef
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 1.0.0
+readme: main:README.md
+createdAt: 1786385513599


### PR DESCRIPTION
Submitting Local Keep AI (`ai.localkeep.unity`) via the package submission form.

Checklist against the package criteria:
- Valid UPM package: `package.json` at the repository root with name `ai.localkeep.unity`
- Open source: MIT (LICENSE at the repo root, `licenseSpdxId: MIT`)
- Hosted on GitHub: https://github.com/laynef/localkeep-unity
- Releases via semver git tags: `v1.0.0` exists; `gitTagPrefix` left empty so future tags build
- Functional: editor-only tooling (asmdef is Editor-scoped) that drives the `lk` CLI
  (`pip install local-keep-ai-cli`); the CLI is resolved from PATH, never bundled
- Not a duplicate of any existing OpenUPM package