### PR TITLE
Add com.kitwright.unity.mcp

### DIFF
--- a/data/packages/com.kitwright.unity.mcp.yml
+++ b/data/packages/com.kitwright.unity.mcp.yml
@@ -1,0 +1,26 @@
+name: com.kitwright.unity.mcp
+aliases: []
+displayName: KitWright MCP for Unity
+description: >-
+  An MCP (Model Context Protocol) server that runs inside the Unity Editor, so
+  MCP clients like Claude Code, Cursor, LM Studio, Windsurf, Codex and VS Code
+  Copilot can inspect and modify the open project directly. Ships 150 editor
+  tools for scenes, scripts, prefabs, assets, play mode automation, input
+  simulation, screenshots and profiling, plus in-editor C# execution, MCP
+  resources and workflow prompts.
+repoUrl: https://github.com/kitwright/unity-mcp
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - ai
+  - code-generation
+  - editor-enhancement
+hunter: loggzix
+gitTagPrefix: v
+gitTagIgnore: ''
+minVersion: 1.0.0
+readme: main:README.md
+readme_zhCN: main:README_CN.md

--- a/data/packages/com.kitwright.unity.mcp.yml
+++ b/data/packages/com.kitwright.unity.mcp.yml
@@ -24,3 +24,4 @@ gitTagIgnore: ''
 minVersion: 1.0.0
 readme: main:README.md
 readme_zhCN: main:README_CN.md
+createdAt: 1786483778696


### PR DESCRIPTION
Adds KitWright MCP for Unity.

- Repo: https://github.com/kitwright/unity-mcp
- License: MIT
- Unity: 2022.3 or newer, editor only
- Tag prefix `v`, first release tagged `v1.0.0`

An MCP server that runs inside the Unity Editor so MCP clients such as Claude Code, Cursor, LM Studio, Windsurf, Codex and VS Code Copilot can inspect and modify the open project. `package.json` sits at the repository root and its only third-party dependency is `com.unity.nuget.newtonsoft-json` from the Unity registry.
