### PR TITLE
Update tracking mode and add GitHub release asset name

### DIFF
--- a/data/packages/com.alicizax.unity.debugger.yml
+++ b/data/packages/com.alicizax.unity.debugger.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: Aliciza X Debugger
 description: Aliciza X Debugger
 repoUrl: https://github.com/AlicizaX/com.alicizax.unity.debugger/
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: com.alicizax.unity.debugger-
 parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0


### PR DESCRIPTION
Changed tracking mode to githubRelease and added githubReleaseAssetName.