### PR TITLE
Update tracking mode and add GitHub release asset name

### DIFF
--- a/data/packages/com.alicizax.unity.ui.extension.yml
+++ b/data/packages/com.alicizax.unity.ui.extension.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: Aliciza X UI Extension
 description: Aliciza X UI Extension
 repoUrl: https://github.com/AlicizaX/com.alicizax.unity.ui.extension
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: com.alicizax.unity.ui.extension-
 parentRepoUrl: null
 licenseSpdxId: Apache-2.0
 licenseName: Apache License 2.0


### PR DESCRIPTION
Changed tracking mode to use GitHub releases and added asset name.