### PR TITLE
Update tracking mode and release asset name

### DIFF
--- a/data/packages/com.alicizax.unity.cysharp.unitask.yml
+++ b/data/packages/com.alicizax.unity.cysharp.unitask.yml
@@ -3,7 +3,8 @@ aliases: []
 displayName: UniTask
 description: Provides an efficient async/await integration to Unity.
 repoUrl: https://github.com/AlicizaX/com.alicizax.unity.cysharp.unitask
-trackingMode: git
+trackingMode: githubRelease
+githubReleaseAssetName: com.alicizax.unity.cysharp.unitask-
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
Changed tracking mode to githubRelease and added githubReleaseAssetName.