### PR TITLE
Use GitHub release tracking for Appstack SDK

### DIFF
--- a/data/packages/com.appstack.unity-sdk.yml
+++ b/data/packages/com.appstack.unity-sdk.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: Appstack SDK
 description: Unity wrapper for the Appstack native attribution SDKs on iOS and Android.
 repoUrl: https://github.com/appstack-tech/appstack-unity-sdk
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
## What changed

Switches `com.appstack.unity-sdk` from Git tag tracking to GitHub Release asset tracking.

## Why

Appstack's release workflow now produces a Unity-signed UPM `.tgz` and attaches it to the matching GitHub Release. OpenUPM must consume that signed release asset unchanged so Unity 6.3+ can verify the package signature.

## Impact

Future Appstack SDK versions will be published from the signed GitHub Release tarball instead of being repacked from the Git checkout.

## Validation

- Changed only `data/packages/com.appstack.unity-sdk.yml`
- `git diff --check` passes
- The first signed version tag will be created only after this metadata change is merged