### PR TITLE
Add com.zzamjak.windable

### DIFF
--- a/data/packages/com.zzamjak.windable.yml
+++ b/data/packages/com.zzamjak.windable.yml
@@ -1,0 +1,20 @@
+name: com.zzamjak.windable
+aliases: []
+displayName: Windable
+description: >-
+  Noise-texture based wind effect component. Auto-detects SpriteRenderer and UI
+  Graphic targets and renders both with a single shader, with Sprite Atlas UV
+  correction and ClipRect (ScrollView) clipping support. Mobile-optimized.
+repoUrl: 'https://github.com/zzamjak-cloud/Windable'
+trackingMode: git
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - particles-and-effects
+  - 2d
+hunter: zzamjak-cloud
+gitTagPrefix: ''
+gitTagIgnore: ''
+image: null
+createdAt: 1786754048000
+readme: 'main:Packages/com.zzamjak.windable/README.md'


### PR DESCRIPTION
## Package

- **Name**: com.zzamjak.windable
- **Repository**: https://github.com/zzamjak-cloud/Windable
- **License**: MIT
- **Latest tag**: v1.0.0

Noise-texture based wind effect for SpriteRenderer and UI Graphic, with Sprite Atlas UV correction and ClipRect clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)