### PR TITLE
chore(data): new package com.zzamjak.colorreplace

### DIFF
--- a/data/packages/com.zzamjak.colorreplace.yml
+++ b/data/packages/com.zzamjak.colorreplace.yml
@@ -1,0 +1,18 @@
+name: com.zzamjak.colorreplace
+displayName: ColorReplace
+description: A mobile-optimized effect component that replaces a specific HSV color range in real time. Supports both SpriteRenderer and uGUI Graphic (Image, RawImage), preserving batching via MaterialPropertyBlock and material caching.
+repoUrl: 'https://github.com/zzamjak-cloud/ColorReplace'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - 2d
+  - gui
+  - particles-and-effects
+hunter: zzamjak-cloud
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'main:Packages/com.zzamjak.colorreplace/README.md'
+createdAt: 1786758468000

--- a/data/packages/com.zzamjak.colorreplace.yml
+++ b/data/packages/com.zzamjak.colorreplace.yml
@@ -1,7 +1,9 @@
 name: com.zzamjak.colorreplace
+aliases: []
 displayName: ColorReplace
 description: A mobile-optimized effect component that replaces a specific HSV color range in real time. Supports both SpriteRenderer and uGUI Graphic (Image, RawImage), preserving batching via MaterialPropertyBlock and material caching.
 repoUrl: 'https://github.com/zzamjak-cloud/ColorReplace'
+trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
New package submission: **com.zzamjak.colorreplace** (ColorReplace)

- Repository: https://github.com/zzamjak-cloud/ColorReplace
- UPM package located at `Packages/com.zzamjak.colorreplace` (monorepo layout)
- License: MIT
- Release tags: `v1.0.0` (semver with v prefix)

A mobile-optimized effect component that replaces a specific HSV color range in real time, supporting both SpriteRenderer and uGUI Graphic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)