### PR TITLE
chore(data): new package com.zzamjak.uishining

### DIFF
--- a/data/packages/com.zzamjak.uishining.yml
+++ b/data/packages/com.zzamjak.uishining.yml
@@ -1,0 +1,18 @@
+name: com.zzamjak.uishining
+displayName: UIShining
+description: A mobile-optimized shine (gloss sweep) loop effect for uGUI Image (atlas sprites) and RawImage. The shine band sweeps across as a convex-lens-like curved band, composited with additive + burn blending.
+repoUrl: 'https://github.com/zzamjak-cloud/UIShining'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - 2d
+  - gui
+  - particles-and-effects
+hunter: zzamjak-cloud
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: null
+readme: 'main:Packages/com.zzamjak.uishining/README.md'
+createdAt: 1786758468000

--- a/data/packages/com.zzamjak.uishining.yml
+++ b/data/packages/com.zzamjak.uishining.yml
@@ -1,7 +1,9 @@
 name: com.zzamjak.uishining
+aliases: []
 displayName: UIShining
 description: A mobile-optimized shine (gloss sweep) loop effect for uGUI Image (atlas sprites) and RawImage. The shine band sweeps across as a convex-lens-like curved band, composited with additive + burn blending.
 repoUrl: 'https://github.com/zzamjak-cloud/UIShining'
+trackingMode: git
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
New package submission: **com.zzamjak.uishining** (UIShining)

- Repository: https://github.com/zzamjak-cloud/UIShining
- UPM package located at `Packages/com.zzamjak.uishining` (monorepo layout)
- License: MIT
- Release tags: `v1.0.0` (semver with v prefix)

A mobile-optimized shine (gloss sweep) loop effect for uGUI Image (atlas sprites) and RawImage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)