### PR TITLE
fix: explain empty GitHub release asset field

### DIFF
--- a/scripts/data-validation-pr-comment.js
+++ b/scripts/data-validation-pr-comment.js
@@ -69,10 +69,10 @@ const fixableIssues = {
     duplicateTerms: ["github.com", "blob", "raw"],
   },
   "package-github-release-asset-name-empty": {
-    title: "Remove an empty `githubReleaseAssetName`",
+    title: "Remove or fill in `githubReleaseAssetName`",
     guidance:
-      "`githubReleaseAssetName` is optional, but it cannot be an empty string when present. Remove the field for Git tracking, or provide the release asset filename when using GitHub Release tracking.",
-    duplicateTerms: ["githubreleaseassetname", "empty string"],
+      "With GitHub Release tracking, `githubReleaseAssetName` is optional but cannot be an empty string when present. Remove the empty field to use automatic asset selection, or provide the release asset filename.",
+    duplicateTerms: ["githubreleaseassetname", "release asset"],
   },
 };
 

--- a/scripts/data-validation-pr-comment.js
+++ b/scripts/data-validation-pr-comment.js
@@ -68,6 +68,12 @@ const fixableIssues = {
       "A plain `github.com/.../blob/...` URL points to a GitHub HTML page instead of image bytes. Use `raw.githubusercontent.com`, a GitHub `/raw/` URL, or add `?raw=true` to the blob URL.",
     duplicateTerms: ["github.com", "blob", "raw"],
   },
+  "package-github-release-asset-name-empty": {
+    title: "Remove an empty `githubReleaseAssetName`",
+    guidance:
+      "`githubReleaseAssetName` is optional, but it cannot be an empty string when present. Remove the field for Git tracking, or provide the release asset filename when using GitHub Release tracking.",
+    duplicateTerms: ["githubreleaseassetname", "empty string"],
+  },
 };
 
 const metadataRequiredFields = [

--- a/test/data-validation-pr-comment.js
+++ b/test/data-validation-pr-comment.js
@@ -124,6 +124,10 @@ describe("data-validation-pr-comment", function() {
         "Use a raw GitHub image URL",
       ],
       [
+        "packages/com.example.tool.yml: githubReleaseAssetName must not be empty when set [package-github-release-asset-name-empty]",
+        "Remove an empty `githubReleaseAssetName`",
+      ],
+      [
         "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
         "Fill in `licenseSpdxId`",
       ],
@@ -180,6 +184,17 @@ describe("data-validation-pr-comment", function() {
 
     assert.ok(body.includes("Use a raw GitHub image URL"));
     assert.ok(body.includes("raw.githubusercontent.com"));
+  });
+
+  it("guides contributors to remove or populate githubReleaseAssetName", function() {
+    const body = buildCommentBody(
+      parseValidationIssues(
+        "packages/com.example.tool.yml: githubReleaseAssetName must not be empty when set [package-github-release-asset-name-empty]"
+      )
+    );
+
+    assert.ok(body.includes("Remove the field for Git tracking"));
+    assert.ok(body.includes("provide the release asset filename when using GitHub Release tracking"));
   });
 
   it("covers supported metadata schema field guidance", function() {

--- a/test/data-validation-pr-comment.js
+++ b/test/data-validation-pr-comment.js
@@ -125,7 +125,7 @@ describe("data-validation-pr-comment", function() {
       ],
       [
         "packages/com.example.tool.yml: githubReleaseAssetName must not be empty when set [package-github-release-asset-name-empty]",
-        "Remove an empty `githubReleaseAssetName`",
+        "Remove or fill in `githubReleaseAssetName`",
       ],
       [
         "packages/com.example.tool.yml: licenseSpdxId must not be an empty string [package-license-spdx-id-empty]",
@@ -186,15 +186,16 @@ describe("data-validation-pr-comment", function() {
     assert.ok(body.includes("raw.githubusercontent.com"));
   });
 
-  it("guides contributors to remove or populate githubReleaseAssetName", function() {
+  it("guides GitHub Release contributors to remove or populate githubReleaseAssetName", function() {
     const body = buildCommentBody(
       parseValidationIssues(
         "packages/com.example.tool.yml: githubReleaseAssetName must not be empty when set [package-github-release-asset-name-empty]"
       )
     );
 
-    assert.ok(body.includes("Remove the field for Git tracking"));
-    assert.ok(body.includes("provide the release asset filename when using GitHub Release tracking"));
+    assert.ok(body.includes("With GitHub Release tracking"));
+    assert.ok(body.includes("Remove the empty field to use automatic asset selection"));
+    assert.ok(body.includes("provide the release asset filename"));
   });
 
   it("covers supported metadata schema field guidance", function() {


### PR DESCRIPTION
## Summary

- add specific contributor guidance for an empty `githubReleaseAssetName`
- explain the Git-tracking and GitHub-Release remediation paths
- cover both paths in the validation-comment formatter tests

## Validation

- npm test