### PR TITLE
chore(data): new package dev.rekonops.rekon

### DIFF
--- a/data/packages/dev.rekonops.rekon.yml
+++ b/data/packages/dev.rekonops.rekon.yml
@@ -1,0 +1,17 @@
+name: dev.rekonops.rekon
+displayName: Rekon
+description: >-
+  Bug reporting infrastructure for Unity game dev teams. Auto-capture
+  video/screenshots/logs from play mode, then route them to a web dashboard and
+  Jira.
+repoUrl: 'https://github.com/RekonOps/Rekon-unity'
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - testing
+  - debugging-and-logging
+  - integration
+hunter: Coffee-Jhin
+gitTagPrefix: ''
+gitTagIgnore: '^v0'
+readme: 'main:README.md'

--- a/data/packages/dev.rekonops.rekon.yml
+++ b/data/packages/dev.rekonops.rekon.yml
@@ -1,10 +1,12 @@
 name: dev.rekonops.rekon
+aliases: []
 displayName: Rekon
 description: >-
   Bug reporting infrastructure for Unity game dev teams. Auto-capture
   video/screenshots/logs from play mode, then route them to a web dashboard and
   Jira.
 repoUrl: 'https://github.com/RekonOps/Rekon-unity'
+trackingMode: git
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
@@ -14,4 +16,5 @@ topics:
 hunter: Coffee-Jhin
 gitTagPrefix: ''
 gitTagIgnore: '^v0'
+createdAt: 1786948358000
 readme: 'main:README.md'


### PR DESCRIPTION
Add package [Rekon](https://github.com/RekonOps/Rekon-unity) (\`dev.rekonops.rekon\`).

- Bug reporting infrastructure for Unity game dev teams — auto-capture video, screenshots, and logs from play mode, routed to a web dashboard and Jira.
- License: MIT
- First OpenUPM release: \`v1.0.0\` (\`gitTagIgnore: '^v0'\` — pre-1.0 tags were released under a different license and are intentionally excluded)