### PR TITLE
chore(data): new package com.zzamjak.imagedeform

### DIFF
--- a/data/packages/com.zzamjak.imagedeform.yml
+++ b/data/packages/com.zzamjak.imagedeform.yml
@@ -1,0 +1,21 @@
+name: com.zzamjak.imagedeform
+aliases: []
+displayName: ImageDeform
+description: >-
+  Puppet-pin mesh deformation for Unity. Place pins on a UI Image/RawImage or
+  SpriteRenderer, then drag them or keyframe them in animation clips — the
+  auto-subdivided mesh deforms smoothly using precomputed weights.
+  Mobile-optimized: change-detection updates, zero per-frame GC allocation,
+  centralized update manager.
+repoUrl: 'https://github.com/zzamjak-cloud/ImageDeform'
+trackingMode: git
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - 2d
+hunter: zzamjak-cloud
+gitTagPrefix: ''
+gitTagIgnore: ''
+image: null
+createdAt: 1787062906000
+readme: 'main:Packages/com.zzamjak.imagedeform/README.md'


### PR DESCRIPTION
New package submission: [com.zzamjak.imagedeform](https://github.com/zzamjak-cloud/ImageDeform)

Puppet-pin mesh deformation for Unity UI (Image/RawImage) and SpriteRenderer. Mobile-optimized, animation-clip friendly.

- License: MIT
- Latest release: v1.0.0
- Package location: `Packages/com.zzamjak.imagedeform` (monorepo subfolder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)