### PR TITLE
Create com.zzamjak.catui.yml

### DIFF
--- a/data/packages/com.zzamjak.catui.yml
+++ b/data/packages/com.zzamjak.catui.yml
@@ -1,0 +1,17 @@
+name: com.zzamjak.catui
+aliases: []
+displayName: CATUI
+description: 'UGUI extension components for Unity: MultiSliceImage (multi-cut sliced image), MirrorSliceImage (symmetric mirrored image with gradient), UIFlip (graphic mesh flip) and UIImageFollow (sprite synchronization). Designed for mobile with bounded vertex counts and GC-free mesh rebuilds.'
+repoUrl: 'https://github.com/zzamjak-cloud/CATUI'
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - gui
+  - 2d
+hunter: zzamjak-cloud
+gitTagPrefix: ''
+gitTagIgnore: ''
+readme: 'main:Packages/com.zzamjak.catui/README.md'
+createdAt: 1787360197197


### PR DESCRIPTION
Adds CATUI — a UGUI extension component set (MultiSliceImage, MirrorSliceImage, UIFlip, UIImageFollow) for Unity 6000.0+.

- Repo: https://github.com/zzamjak-cloud/CATUI
- Package path: `Packages/com.zzamjak.catui`
- License: MIT
- Tags: `v1.0.0`, `v1.0.1`
- Verified building against Unity 6000.0.69f1 (Android IL2CPP, managed stripping High).