### PR TITLE
fix(data): ImageDeform 라이선스를 GPL-3.0-only로 갱신

### DIFF
--- a/data/packages/com.zzamjak.imagedeform.yml
+++ b/data/packages/com.zzamjak.imagedeform.yml
@@ -9,8 +9,8 @@ description: >-
   centralized update manager.
 repoUrl: 'https://github.com/zzamjak-cloud/ImageDeform'
 trackingMode: git
-licenseSpdxId: MIT
-licenseName: MIT License
+licenseSpdxId: GPL-3.0-only
+licenseName: GNU General Public License v3.0 only
 topics:
   - 2d
 hunter: zzamjak-cloud


### PR DESCRIPTION
## 변경 사항

- `com.zzamjak.imagedeform`의 OpenUPM 카탈로그 라이선스를 `MIT`에서 `GPL-3.0-only`로 갱신합니다.
- 패키지의 [v2.0.0 릴리스](https://github.com/zzamjak-cloud/ImageDeform/releases/tag/v2.0.0) 및 `package.json`과 일치시킵니다.

## 호환성

기존 v1.0.0 배포물의 MIT 라이선스 조건은 그대로 유지되며, GPL-3.0-only는 v2.0.0부터 적용됩니다.

## 검증

- `git diff --check` 통과
- 데이터 테스트 20개 통과
- 전체 데이터 검증 1건은 로컬에 빌드된 `openupm-next` 공유 validator가 없어 실행되지 않았으며 PR CI에서 확인합니다.