### PR TITLE
Update PathFollower license metadata

### DIFF
--- a/data/packages/com.zzamjak.pathfollower.yml
+++ b/data/packages/com.zzamjak.pathfollower.yml
@@ -7,8 +7,8 @@ description: >-
   agents, and a tiling sprite ribbon (PathRibbon).
 repoUrl: 'https://github.com/zzamjak-cloud/PathFollower'
 trackingMode: git
-licenseSpdxId: MIT
-licenseName: MIT License
+licenseSpdxId: GPL-3.0-only
+licenseName: GNU General Public License v3.0 only
 topics:
   - animation
   - utilities


### PR DESCRIPTION
Updates com.zzamjak.pathfollower license metadata to match the package's GPL-3.0-only license as of PathFollower v1.0.3.\n\nPathFollower release tag: https://github.com/zzamjak-cloud/PathFollower/releases/tag/v1.0.3