### PR TITLE
Add com.tesseractsoftwares.praxsuite (Praxsuite SDK for Unity)

### DIFF
--- a/data/packages/com.tesseractsoftwares.praxsuite.yml
+++ b/data/packages/com.tesseractsoftwares.praxsuite.yml
@@ -1,0 +1,23 @@
+name: com.tesseractsoftwares.praxsuite
+aliases: []
+displayName: Praxsuite SDK
+description: >-
+  Backend-as-a-service for Unity games - player accounts, saves, leaderboards,
+  inventories, files and server-authoritative logic, with no server code to
+  write. Zero dependencies.
+repoUrl: 'https://github.com/TesseractSoftwares/Praxsuite-SDK-Unity'
+trackingMode: git
+parentRepoUrl: null
+licenseName: Praxsuite Open SDK Licence v1.0
+licenseSpdxId: null
+image: null
+topics:
+  - services
+  - network
+  - data-management
+hunter: VinsDepassier
+gitTagPrefix: v
+gitTagIgnore: ''
+minVersion: 1.0.0
+readme: 'master:README.md'
+createdAt: 1787508641108


### PR DESCRIPTION
Adds the Praxsuite SDK for Unity — backend-as-a-service for Unity games: player accounts, saves, leaderboards, inventories, files, and server-authoritative logic, with no server code to write.

- **Repo:** https://github.com/TesseractSoftwares/Praxsuite-SDK-Unity
- **Package:** `com.tesseractsoftwares.praxsuite` — at the repo root, Unity 2021.3+
- **Tags:** `v1.0.0`, hence `gitTagPrefix: v`
- **Dependencies:** none

A note on the licence field, since it is set to `null`: the SDK ships under the Praxsuite Open SDK Licence v1.0, which is source-available rather than OSI-approved. It is free to use in any project including commercial ones, free to fork and modify, and free to redistribute with attribution retained; what it restricts is reselling the SDK itself or using it to power a competing backend. `licenseSpdxId` is therefore `null` with a plain `licenseName`, following the precedent of entries such as `com.pixelwizards.utilities` (Unity Companion License). Happy to adjust if you would rather it were recorded differently.