### PR TITLE
Create com.atticar.deep-clone-lite.yml

### DIFF
--- a/data/packages/com.atticar.deep-clone-lite.yml
+++ b/data/packages/com.atticar.deep-clone-lite.yml
@@ -1,0 +1,20 @@
+name: com.atticar.deep-clone-lite
+aliases: []
+displayName: Deep Clone Lite
+description: Minimal ScriptableObject deep-cloning utility for Unity.
+repoUrl: https://github.com/Culzean/unity-scriptableobject-deep-clone
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: >-
+  https://raw.githubusercontent.com/Culzean/unity-scriptableobject-deep-clone/main/Images~/DeepClone_OpenUPM_600x300.png
+topics:
+  - asset-management
+  - editor-enhancement
+  - utilities
+hunter: culzean
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: v1.0.0
+readme: main:README.md


### PR DESCRIPTION
Adds Deep Clone Lite - a minimal ScriptableObject deep-cloning utility for the Unity Editor. Walks nested SO hierarchies via reflection, duplicates every child as an independent asset, and rewires references automatically.

* Repo: https://github.com/Culzean/unity-scriptableobject-deep-clone
* Package: `com.atticar.deep-clone-lite` at the repo root, Unity 2020.3+
* Tags: `v1.0.0`
* Dependencies: none
* Licence: MIT