### PR TITLE
Add package app.kraty.sdk

### DIFF
--- a/data/packages/app.kraty.sdk.yml
+++ b/data/packages/app.kraty.sdk.yml
@@ -1,0 +1,20 @@
+name: app.kraty.sdk
+displayName: Kraty SDK
+description: >-
+  C# client SDK for the Kraty game-events platform. Targets the public /sdk/v1
+  surface: events, leaderboards, grants, crates, lobbies. Built on .NET Standard
+  2.1 for Unity 2022 LTS+ and any modern .NET runtime.
+repoUrl: 'https://github.com/Kraty-Org/kraty-sdk-unity'
+parentRepoUrl: null
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: ''
+image: ''
+readme: 'main:README.md'
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - leaderboard
+  - live-ops
+  - events
+hunter: gbanha

--- a/data/packages/app.kraty.sdk.yml
+++ b/data/packages/app.kraty.sdk.yml
@@ -14,8 +14,7 @@ readme: 'main:README.md'
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
-  - leaderboard
-  - live-ops
-  - events
+  - network
+  - services
 hunter: gbanha
 createdAt: 1787675633000

--- a/data/packages/app.kraty.sdk.yml
+++ b/data/packages/app.kraty.sdk.yml
@@ -4,11 +4,11 @@ description: >-
   C# client SDK for the Kraty game-events platform. Targets the public /sdk/v1
   surface: events, leaderboards, grants, crates, lobbies. Built on .NET Standard
   2.1 for Unity 2022 LTS+ and any modern .NET runtime.
+aliases: []
 repoUrl: 'https://github.com/Kraty-Org/kraty-sdk-unity'
-parentRepoUrl: null
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+trackingMode: git
 image: ''
 readme: 'main:README.md'
 licenseSpdxId: MIT
@@ -18,3 +18,4 @@ topics:
   - live-ops
   - events
 hunter: gbanha
+createdAt: 1787675633000


### PR DESCRIPTION
Adds the Kraty Unity SDK (app.kraty.sdk), a public C# client SDK mirrored to https://github.com/Kraty-Org/kraty-sdk-unity with vX.Y.Z tags.