### PR TITLE
Add package com.zzamjak.tilemapmaker

### DIFF
--- a/data/packages/com.zzamjak.tilemapmaker.yml
+++ b/data/packages/com.zzamjak.tilemapmaker.yml
@@ -1,0 +1,24 @@
+name: com.zzamjak.tilemapmaker
+aliases: []
+displayName: CAT TileMapMaker
+description: >-
+  Unity editor tool that turns a StyleStudio tileset folder into a working
+  tilemap in one pass: batch sprite import settings (PPU, FullRect, extrude 0,
+  clamp, no mipmap), blob-47 Rule Tile generation from IMPORT_GUIDE.txt with
+  variant tiles grouped as random output, a base Tile asset, a Tile Palette
+  prefab with its GridPalette sub-asset, and a Grid / Ground / Terrain scene
+  hierarchy with optional CompositeCollider2D.
+repoUrl: 'https://github.com/zzamjak-cloud/TileMapMaker'
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - 2d
+  - level-design
+  - editor-enhancement
+hunter: zzamjak-cloud
+gitTagPrefix: ''
+gitTagIgnore: ''
+readme: 'main:Packages/com.zzamjak.tilemapmaker/README.md'
+createdAt: 1787879235000


### PR DESCRIPTION
Add [CAT TileMapMaker](https://github.com/zzamjak-cloud/TileMapMaker) — a Unity 6 editor tool that converts a StyleStudio tileset folder into a working tilemap (sprite import settings, blob-47 Rule Tile, base Tile, Tile Palette, and scene Grid/Tilemap hierarchy).

- Package path: `Packages/com.zzamjak.tilemapmaker` (embedded package in a Unity dev project repo)
- License: MIT (`LICENSE.md` in the package folder)
- Tags: `v0.1.0`, `v0.2.0` — `gitTagPrefix` empty
- Dependencies: `com.unity.2d.tilemap` (builtin), `com.unity.2d.tilemap.extras@4.1.1` (Unity registry)
- Same repo layout and conventions as my other `com.zzamjak.*` packages already on OpenUPM.