### PR TITLE
Create com.ayutaz.opencv-unity-native.yml

### DIFF
--- a/data/packages/com.ayutaz.opencv-unity-native.yml
+++ b/data/packages/com.ayutaz.opencv-unity-native.yml
@@ -1,0 +1,28 @@
+name: com.ayutaz.opencv-unity-native
+aliases: []
+displayName: OpenCV Unity Native
+description: >-
+  OpenCV 5 for Unity through a project-owned C ABI. Ships prebuilt native
+  binaries for Windows x64, macOS arm64 and Linux x64 in a single package, so
+  one dependency covers the editor and the build target.
+
+
+  Not a wrapper around OpenCvSharp. The C ABI is versioned, IL2CPP-safe and
+  built reproducibly by CI; ownership, stride and error handling are contract
+  tested. Requires Unity 6000.3 or newer.
+repoUrl: https://github.com/ayutaz/OpenCVUnityNative
+trackingMode: githubRelease
+githubReleaseAssetName: com.ayutaz.opencv-unity-native.tgz
+parentRepoUrl: null
+licenseSpdxId: Apache-2.0
+licenseName: Apache License 2.0
+image: ''
+topics:
+  - integration
+  - utilities
+hunter: ayutaz
+gitTagPrefix: 'v'
+gitTagIgnore: ''
+minVersion: '0.2.0'
+readme: main:README.md
+createdAt: 1788065874335


### PR DESCRIPTION
## Package

| | |
| --- | --- |
| **Package id** | `com.ayutaz.opencv-unity-native` |
| **Repository** | https://github.com/ayutaz/OpenCVUnityNative |
| **License** | Apache-2.0 (`LICENSE` at the repo root; `THIRD_PARTY_NOTICES.md` reproduces the notices for everything OpenCV bundles into the shipped binaries) |
| **Tracking mode** | `githubRelease` |
| **Asset** | `com.ayutaz.opencv-unity-native.tgz` |
| **minVersion** | `0.2.0` |
| **Topics** | `integration`, `utilities` |

OpenCV 5 for Unity through a project-owned C ABI, published as a UPM tarball that
carries prebuilt native binaries for Windows x64, macOS arm64 and Linux x64.

## Why `trackingMode: githubRelease`

The native binaries are deliberately **not** tracked in git — three platforms' worth of
build output on every commit would grow the history without bound. A source tarball built
from a git tag would therefore ship only the `.meta` files and no libraries, and every
`DllImport` would fail at runtime. The release workflow builds the three platforms, packs
them into one tarball and attaches it to the GitHub Release, so `githubRelease` publishes
the artifact that actually works.

## Why the asset name carries no version

`com.ayutaz.opencv-unity-native.tgz` is stable across releases, so this manifest does not
need editing per version. The same release also carries three per-platform tarballs named
`com.ayutaz.opencv-unity-native-<version>-<platform>.tgz`; the value above matches the
all-platform one **exactly**, so the prefix fallback is never reached and the per-platform
assets cannot be selected by mistake.

## Validation

The shared validator was **not** run locally — `npm test` needs a built `openupm-next`
checkout, which I did not have. What I did check locally against this repository's data:

- the filename matches the `name` field
- no package with this id already exists (scanned the 3895 files in `data/packages`)
- both topics are real slugs in `data/topics.yml`
- the key set and order match a recently merged submission, plus `githubReleaseAssetName`
- two-space YAML indentation

And against the published release:

- `v0.2.0` exists and is not a draft, so `minVersion` points at a real tag
- `releases/latest/download/com.ayutaz.opencv-unity-native.tgz` downloads anonymously,
  its SHA-256 matches the `SHA256SUMS.txt` in the same release, and the `package.json`
  inside reports `"version": "0.2.0"` and `"unity": "6000.3"`
- the tarball is npm-style (`package/` at the root) and contains all three native libraries

Please tell me if anything here should be adjusted.