### PR TITLE
chore(data): new package com.arman.service-locating

### DIFF
--- a/data/packages/com.arman.service-locating.yml
+++ b/data/packages/com.arman.service-locating.yml
@@ -1,0 +1,20 @@
+name: com.arman.service-locating
+aliases: []
+displayName: Service Locating
+description: >-
+  A static service locator for Unity. Register implementations against an interface,
+  resolve them anywhere with Find<T>(), and replace or clear registrations for testing.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.service-locating/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/ServiceLocating/README.md
+createdAt: 1788091545347


### PR DESCRIPTION
Adds `com.arman.service-locating` — a static service locator for Unity: register implementations
against an interface, resolve them anywhere with `Find<T>()`, and replace or clear registrations
for testing.

- **Repo:** https://github.com/jahandideh-iman/unitypackages (public, MIT)
- **Package path:** `Packages/ServiceLocating/`
- **Tag:** [`com.arman.service-locating/0.1.0`](https://github.com/jahandideh-iman/unitypackages/releases/tag/com.arman.service-locating%2F0.1.0)

This is a monorepo hosting several embedded UPM packages, so `gitTagPrefix` is set to
`com.arman.service-locating/` to scope discovery to this package's own tags. It is the first of the
set to be submitted; the others will follow once this one is confirmed working.
