### PR TITLE
Rename com.yuna0x0.basis.convert to Watari (Converter for Basis)

### DIFF
--- a/data/packages/com.yuna0x0.basis.convert.yml
+++ b/data/packages/com.yuna0x0.basis.convert.yml
@@ -1,6 +1,6 @@
 name: com.yuna0x0.basis.convert
 aliases: []
-displayName: Basis Convert
+displayName: Watari (Converter for Basis)
 description: >-
   Convert avatars, clothing and props from other social VR platforms for use
   with Basis: physics, constraints, the avatar descriptor and menu toggles.

--- a/data/packages/com.yuna0x0.basis.convert.yml
+++ b/data/packages/com.yuna0x0.basis.convert.yml
@@ -4,7 +4,7 @@ displayName: Watari (Converter for Basis)
 description: >-
   Convert avatars, clothing and props from other social VR platforms for use
   with Basis: physics, constraints, the avatar descriptor and menu toggles.
-repoUrl: https://github.com/yuna0x0/basis-convert
+repoUrl: https://github.com/yuna0x0/watari-basis
 trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT


### PR DESCRIPTION
The package was renamed upstream and the repository moved to yuna0x0/watari-basis. Updates the display name and repoUrl to match.