### PR TITLE
Add 16 com.arman.* packages from jahandideh-iman/unitypackages

### DIFF
--- a/data/packages/com.arman.asset-providing.yml
+++ b/data/packages/com.arman.asset-providing.yml
@@ -1,0 +1,21 @@
+name: com.arman.asset-providing
+aliases: []
+displayName: Asset Providing
+description: >-
+  Loads Unity assets through pluggable providers, by id or by type, synchronously or
+  asynchronously. Providers can be chained so a lookup falls through to the next one, and
+  configured as ScriptableObject assets in the Editor.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - asset-management
+  - frameworks
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.asset-providing/
+gitTagIgnore: ''
+minVersion: ''
+readme: "master:Packages/Asset Providing/README.md"
+createdAt: 1788160312088

--- a/data/packages/com.arman.component-system.yml
+++ b/data/packages/com.arman.component-system.yml
@@ -1,0 +1,21 @@
+name: com.arman.component-system
+aliases: []
+displayName: Component System
+description: >-
+  A lightweight composition framework for building entities out of interchangeable components.
+  Provides entity/component abstractions, specialized single-component entities, and a caching
+  entity that avoids repeated component lookups.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.component-system/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/ComponentSystem/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.configuration-management.yml
+++ b/data/packages/com.arman.configuration-management.yml
@@ -1,0 +1,22 @@
+name: com.arman.configuration-management
+aliases: []
+displayName: Configuration Management
+description: >-
+  Applies configuration to objects through registered configurers. A configuration manager
+  resolves the configurer for a target type and configures it; composite and dynamic
+  configurers combine behaviour, and ScriptableObject-backed configurers let data designers
+  author values in the Editor.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - data-management
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.configuration-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/ConfigurationManagement/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.development-console.yml
+++ b/data/packages/com.arman.development-console.yml
@@ -1,0 +1,21 @@
+name: com.arman.development-console
+aliases: []
+displayName: Development Console
+description: >-
+  An in-game development console. Methods marked with [DevOption] are discovered by reflection
+  and surfaced as grouped, clickable commands with optional key-combination shortcuts and
+  typed argument prompts. Includes an on-screen FPS profiler.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - debugging-and-logging
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.development-console/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/DevelopmentConsole/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.event-management.yml
+++ b/data/packages/com.arman.event-management.yml
@@ -1,0 +1,21 @@
+name: com.arman.event-management
+aliases: []
+displayName: Event Management
+description: >-
+  Pub-sub event broadcasting with typed listener registration. Events are dispatched over a
+  snapshot of the listener list, so handlers may register or unregister while an event is
+  being delivered.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.event-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/EventManagement/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.http-connection.yml
+++ b/data/packages/com.arman.http-connection.yml
@@ -1,0 +1,21 @@
+name: com.arman.http-connection
+aliases: []
+displayName: Http Connection
+description: >-
+  A UnityWebRequest wrapper. Build a request with a fluent builder (method, URL, headers,
+  query parameters, body, timeout) and send it through a service that reports the result via
+  success and failure callbacks.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - network
+  - integration
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.http-connection/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/HttpConnection/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.in-game-message-logging.yml
+++ b/data/packages/com.arman.in-game-message-logging.yml
@@ -1,0 +1,20 @@
+name: com.arman.in-game-message-logging
+aliases: []
+displayName: In Game Message Logging
+description: >-
+  Displays log messages inside a running game as a capped, self-expiring on-screen list, so
+  issues can be diagnosed on device without attaching an editor or an external debugger.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - debugging-and-logging
+  - gui
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.in-game-message-logging/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/InGameMessageLogging/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.inventory-system.yml
+++ b/data/packages/com.arman.inventory-system.yml
@@ -1,0 +1,20 @@
+name: com.arman.inventory-system
+aliases: []
+displayName: Inventory System
+description: >-
+  Generic item tracking with quantity management, constraint-based validation (min/max), and
+  subscription callbacks for change notifications.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.inventory-system/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/InventorySystem/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.object-pooling.yml
+++ b/data/packages/com.arman.object-pooling.yml
@@ -1,0 +1,20 @@
+name: com.arman.object-pooling
+aliases: []
+displayName: Object Pooling
+description: >-
+  Reusable object management with acquire/release patterns, Monobehavior and ScriptableObject
+  implementations for zero-allocation game loops.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.object-pooling/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/ObjectPooling/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.package-basics.yml
+++ b/data/packages/com.arman.package-basics.yml
@@ -1,0 +1,20 @@
+name: com.arman.package-basics
+aliases: []
+displayName: Package Basics
+description: >-
+  Pure C# utility abstractions for container types, channel interfaces, and serialization
+  without Unity dependencies.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.package-basics/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/PackageBasics/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.persistent-data-management.yml
+++ b/data/packages/com.arman.persistent-data-management.yml
@@ -1,0 +1,20 @@
+name: com.arman.persistent-data-management
+aliases: []
+displayName: Persistent Data Management
+description: >-
+  Serializable data persistence layer with JSON wrapper, PlayerPrefs storage, file I/O via
+  custom streams, and per-channel serialization support.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - data-management
+  - frameworks
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.persistent-data-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/PersistentDataManagement/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.scene-management.yml
+++ b/data/packages/com.arman.scene-management.yml
@@ -1,0 +1,21 @@
+name: com.arman.scene-management
+aliases: []
+displayName: Scene Management
+description: >-
+  A scene loading helper plus SceneInitilizer, an abstract MonoBehaviour that runs a per-scene
+  Init() from Awake at an early execution order, giving each scene a deterministic bootstrap
+  point.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.scene-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: "master:Packages/Scene Management/README.md"
+createdAt: 1788160312088

--- a/data/packages/com.arman.shop-management.yml
+++ b/data/packages/com.arman.shop-management.yml
@@ -1,0 +1,21 @@
+name: com.arman.shop-management
+aliases: []
+displayName: Shop Management
+description: >-
+  Storefront and purchasing logic for in-game shops. Models shop packages (including composite
+  bundles), routes purchases through pluggable purchase handlers, applies the package on
+  success, and reports success or failure results.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - services
+  - frameworks
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.shop-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/ShopManagement/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.ui-management.yml
+++ b/data/packages/com.arman.ui-management.yml
@@ -1,0 +1,20 @@
+name: com.arman.ui-management
+aliases: []
+displayName: UI Management
+description: >-
+  Canvas-based UI framework with MainWindow/Popup Window stack hierarchy, back-button
+  navigation, and focus-aware panel layering.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - gui
+  - frameworks
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.ui-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: "master:Packages/UI Management/README.md"
+createdAt: 1788160312088

--- a/data/packages/com.arman.unity-utilities.yml
+++ b/data/packages/com.arman.unity-utilities.yml
@@ -1,0 +1,21 @@
+name: com.arman.unity-utilities
+aliases: []
+displayName: Unity Utilities
+description: >-
+  Assorted Unity helpers used across the Arman packages: a coroutine-based delay timer, legacy
+  Animation playback and animator event plumbing, a UnityEvent delegator, and serializable
+  UnityEvent variants for bool, int, float and string.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - utilities
+  - frameworks
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.unity-utilities/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/UnityUtilities/README.md
+createdAt: 1788160312088

--- a/data/packages/com.arman.update-management.yml
+++ b/data/packages/com.arman.update-management.yml
@@ -1,0 +1,21 @@
+name: com.arman.update-management
+aliases: []
+displayName: Update Management
+description: >-
+  Channel-based update loop management. Register IUpdatable objects against named channels,
+  nest channels inside one another, then pause, resume or time-scale a channel and everything
+  below it. A MonoBehaviour adapter drives the whole thing from Unity’s update loop.
+repoUrl: https://github.com/jahandideh-iman/unitypackages
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - frameworks
+  - utilities
+hunter: jahandideh-iman
+gitTagPrefix: com.arman.update-management/
+gitTagIgnore: ''
+minVersion: ''
+readme: master:Packages/UpdateManagement/README.md
+createdAt: 1788160312088


### PR DESCRIPTION
Adds the remaining 16 packages from https://github.com/jahandideh-iman/unitypackages, a monorepo of embedded UPM packages. `com.arman.service-locating` from the same repo was submitted earlier and is already live; these 16 follow the same shape.

All 16 are MIT, tagged `<package-name>/<version>` on `master`, and currently at `0.1.0`:

`asset-providing` · `component-system` · `configuration-management` · `development-console` · `event-management` · `http-connection` · `in-game-message-logging` · `inventory-system` · `object-pooling` · `package-basics` · `persistent-data-management` · `scene-management` · `shop-management` · `ui-management` · `unity-utilities` · `update-management`

Each `package.json` lives at `Packages/<Folder>/package.json`, so `gitTagPrefix` is set per package and `minVersion`/`gitTagIgnore` are left empty — no version predates the current tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PmLUs8dtL286nwtjSf8nP
