### PR TITLE
Update com.zzamjak.* license metadata to GPL-3.0-only

### DIFF
--- a/data/packages/com.zzamjak.uvpatternflow.yml
+++ b/data/packages/com.zzamjak.uvpatternflow.yml
@@ -7,8 +7,8 @@ description: >-
   Mask/RectMask2D. Mobile-optimized (no per-frame GC, branchless shaders).
 repoUrl: 'https://github.com/zzamjak-cloud/UVPatternFlow'
 trackingMode: git
-licenseSpdxId: MIT
-licenseName: MIT License
+licenseSpdxId: GPL-3.0-only
+licenseName: GNU General Public License v3.0 only
 topics:
   - gui
   - particles-and-effects

--- a/data/packages/com.zzamjak.water2d.yml
+++ b/data/packages/com.zzamjak.water2d.yml
@@ -17,8 +17,8 @@ description: >-
 repoUrl: 'https://github.com/zzamjak-cloud/Water2D'
 trackingMode: git
 parentRepoUrl: null
-licenseSpdxId: MIT
-licenseName: MIT License
+licenseSpdxId: GPL-3.0-only
+licenseName: GNU General Public License v3.0 only
 topics:
   - 2d
   - particles-and-effects


### PR DESCRIPTION
Both packages are registered as MIT, but they were relicensed to `GPL-3.0-only` and the registry metadata was never updated. As a result the OpenUPM package pages currently show an incorrect license.

I am the author and maintainer of both packages (`hunter: zzamjak-cloud`).

### com.zzamjak.uvpatternflow

Relicensed in v1.1.1.

- `package.json` → `"license": "GPL-3.0-only"` — https://github.com/zzamjak-cloud/UVPatternFlow/blob/main/Packages/com.zzamjak.uvpatternflow/package.json
- `LICENSE` (GPL-3.0 full text) at repo root — https://github.com/zzamjak-cloud/UVPatternFlow/blob/main/LICENSE
- CHANGELOG entry for 1.1.1 — https://github.com/zzamjak-cloud/UVPatternFlow/blob/main/Packages/com.zzamjak.uvpatternflow/CHANGELOG.md

### com.zzamjak.water2d

Relicensed in v1.0.1.

- `package.json` → `"license": "GPL-3.0-only"` — https://github.com/zzamjak-cloud/Water2D/blob/main/Packages/com.zzamjak.water2d/package.json
- `LICENSE` (GPL-3.0 full text) at repo root — https://github.com/zzamjak-cloud/Water2D/blob/main/LICENSE
- CHANGELOG entry for 1.0.1 — https://github.com/zzamjak-cloud/Water2D/blob/main/Packages/com.zzamjak.water2d/CHANGELOG.md

Only `licenseSpdxId` and `licenseName` are changed; no other fields are touched.
