### PR TITLE
Create com.interneted.ai-agent-config.yml

### DIFF
--- a/data/packages/com.interneted.ai-agent-config.yml
+++ b/data/packages/com.interneted.ai-agent-config.yml
@@ -1,8 +1,10 @@
 name: com.interneted.ai-agent-config
+aliases: []
 displayName: AI Agent Config
 description: Maintain MCP servers and Agent Skills once for Claude Code and Codex.
 repoUrl: 'https://github.com/InternetED/ai-agent-config'
 parentRepoUrl: null
+trackingMode: git
 licenseSpdxId: MIT
 licenseName: MIT License
 topics:
@@ -14,5 +16,6 @@ gitTagPrefix: ''
 gitTagIgnore: '-master$'
 minVersion: '0.1.0'
 image: null
+createdAt: 1788372085145
 readme: 'main:README.md'
 hunter: InternetED

--- a/data/packages/com.interneted.ai-agent-config.yml
+++ b/data/packages/com.interneted.ai-agent-config.yml
@@ -1,0 +1,18 @@
+name: com.interneted.ai-agent-config
+displayName: AI Agent Config
+description: Maintain MCP servers and Agent Skills once for Claude Code and Codex.
+repoUrl: 'https://github.com/InternetED/ai-agent-config'
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - ai
+  - editor-enhancement
+  - integration
+  - utilities
+gitTagPrefix: ''
+gitTagIgnore: '-master$'
+minVersion: '0.1.0'
+image: null
+readme: 'main:README.md'
+hunter: InternetED


### PR DESCRIPTION
Adds the public UPM package `com.interneted.ai-agent-config`, which installs and synchronizes shared MCP and Agent Skills configuration for Claude Code and Codex. The repository is MIT licensed, tagged at `v0.1.0`, and validated with `npm pack --dry-run`.