### PR TITLE
Update tracking mode for SimpleScroll

### DIFF
--- a/data/packages/com.github.kurobon.simple_scroll.yml
+++ b/data/packages/com.github.kurobon.simple_scroll.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: SimpleScroll
 description: SimpleScroll
 repoUrl: https://github.com/kurobon-jp/SimpleScroll
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
*   Changed the `trackingMode` for the `com.github.kurobon.simple_scroll` package.
*   The tracking mode was updated from `git+` to `githubRelease`.
*   This change aims to improve the accuracy and specificity of release tracking for SimpleScroll.