### PR TITLE
com.ayutaz.opencv-unity-native: list all six platforms

### DIFF
--- a/data/packages/com.ayutaz.opencv-unity-native.yml
+++ b/data/packages/com.ayutaz.opencv-unity-native.yml
@@ -3,8 +3,9 @@ aliases: []
 displayName: OpenCV Unity Native
 description: >-
   OpenCV 5 for Unity through a project-owned C ABI. Ships prebuilt native
-  binaries for Windows x64, macOS arm64 and Linux x64 in a single package, so
-  one dependency covers the editor and the build target.
+  binaries for Windows x64, macOS arm64, Linux x64, Android arm64-v8a, iOS
+  arm64 and Web (WebGL) in a single package, so one dependency covers the
+  editor and the build target.
 
 
   Not a wrapper around OpenCvSharp. The C ABI is versioned, IL2CPP-safe and


### PR DESCRIPTION
The package now ships **Android arm64-v8a, iOS arm64 and Web (WebGL)** alongside the three desktop platforms, all inside the single all-platform tarball that `githubReleaseAssetName` selects. The description still listed only the three desktop ones, which understates what a single dependency covers.

`v0.3.0` (published 2026-09-04) is the first release carrying all six, and OpenUPM is already serving it — `dist-tags.latest` is `0.3.0`.

Only the `description` field changes; no tracking or asset settings are touched.