### PR TITLE
Fix: Correct tracking mode for SmartDebugger

### DIFF
--- a/data/packages/com.github.kurobon.smart_debugger.yml
+++ b/data/packages/com.github.kurobon.smart_debugger.yml
@@ -3,7 +3,7 @@ aliases: []
 displayName: SmartDebugger
 description: SmartDebugger
 repoUrl: https://github.com/kurobon-jp/SmartDebugger
-trackingMode: git
+trackingMode: githubRelease
 parentRepoUrl: null
 licenseSpdxId: MIT
 licenseName: MIT License


### PR DESCRIPTION
* Updated `trackingMode` from `git+trackingMode: githubRelease` to `githubRelease`.
* Removed the redundant `git+` prefix, simplifying the tracking mode definition for GitHub releases.