### PR TITLE
Create dev.keylight.sdk.yml

### DIFF
--- a/data/packages/dev.keylight.sdk.yml
+++ b/data/packages/dev.keylight.sdk.yml
@@ -1,0 +1,24 @@
+name: dev.keylight.sdk
+aliases: []
+displayName: Keylight
+description: >-
+  Offline-first licensing for Unity — signed Ed25519 leases, activations and
+  entitlements, with a trial and free tier that keep working without a network.
+repoUrl: 'https://github.com/keylight-dev/keylight-csharp'
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+topics:
+  - services
+  - integration
+hunter: halloweedev
+gitTagPrefix: 'v'
+gitTagIgnore: ''
+minVersion: '0.3.0'
+image: ''
+readme: 'main:README.md'
+readme_zhCN: ''
+displayName_zhCN: ''
+description_zhCN: ''
+createdAt: 1788700000000


### PR DESCRIPTION
Adds `dev.keylight.sdk` — Keylight, offline-first licensing for Unity.

Signed Ed25519 leases, activations and entitlements, with a trial and free tier that keep working without a network. Targets `netstandard2.0`, Unity 2021.3+, zero runtime dependencies.

- **Repo:** https://github.com/keylight-dev/keylight-csharp
- **Package path:** `unity/dev.keylight.sdk`
- **License:** MIT
- **Tags:** `v`-prefixed, so `gitTagPrefix: 'v'`

`minVersion: '0.3.0'` is set deliberately: the Unity `package.json` version lagged the repo tag before 0.3.0, so earlier tags would not build.