### PR TITLE
Update and rename com.sxm.ui-factory.yml to com.sxm-tools.ui-factory.yml

### DIFF
--- a/data/packages/com.sxm-tools.ui-factory.yml
+++ b/data/packages/com.sxm-tools.ui-factory.yml
@@ -1,9 +1,11 @@
-name: com.sxm.ui-factory
-aliases: []
+name: com.sxm-tools.ui-factory
+aliases:
+  - com.sxm.ui-factory
 displayName: UI Factory
 description: >-
-  Factory of various UI components, from primitives (line, point) to complex
-  objects (graph). UI meshes support conversion to uGUI and UIElements formats.
+  Mesh builder for custom UI Toolkit controls: describe a line, a point marker,
+  a series of points or a whole graph, and the factory builds and caches the
+  mesh for generateVisualContent. Geometry is Burst-compiled.
 repoUrl: https://github.com/sxm-sxpxxl/ui-factory
 trackingMode: git
 parentRepoUrl: null
@@ -18,6 +20,6 @@ topics:
 hunter: sxm-sxpxxl
 gitTagPrefix: ''
 gitTagIgnore: ''
-minVersion: ''
+minVersion: '3.0.0'
 readme: master:README.md
 createdAt: 1754400408639


### PR DESCRIPTION
The package was renamed from `com.sxm.ui-factory` to `com.sxm-tools.ui-factory` in its `package.json` starting with v3.0.0, so every build since then fails with E800. This follows the "Renaming a package" recipe from the docs: the metadata file is renamed, the old name goes to `aliases`, and `minVersion` skips the tags that still carry the old name. The repository, license and image are unchanged.