### PR TITLE
Add Jeomseon Awaitable, ownership, and Reactive UI packages

### DIFF
--- a/data/packages/com.jeomseon.unity.addressables.ownership.yml
+++ b/data/packages/com.jeomseon.unity.addressables.ownership.yml
@@ -1,0 +1,19 @@
+name: com.jeomseon.unity.addressables.ownership
+aliases: []
+displayName: Jeomseon Unity Addressables Ownership
+description: >-
+  Generated owner-lifetime management for Addressables assets, collections, and instances.
+repoUrl: https://github.com/jeomseon0516/Unity.Addressables.Ownership
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - utilities
+hunter: jeomseon0516
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.1
+readme: main:README.md
+createdAt: 1789140246941

--- a/data/packages/com.jeomseon.unity.awaitable.yml
+++ b/data/packages/com.jeomseon.unity.awaitable.yml
@@ -1,0 +1,19 @@
+name: com.jeomseon.unity.awaitable
+aliases: []
+displayName: Jeomseon Unity Awaitable
+description: >-
+  Composition and condition-wait helpers for Unity Awaitable.
+repoUrl: https://github.com/jeomseon0516/Unity.Awaitable
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - utilities
+hunter: jeomseon0516
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.0
+readme: main:README.md
+createdAt: 1789140246941

--- a/data/packages/com.jeomseon.unity.game-object-pooling.ownership.yml
+++ b/data/packages/com.jeomseon.unity.game-object-pooling.ownership.yml
@@ -1,0 +1,19 @@
+name: com.jeomseon.unity.game-object-pooling.ownership
+aliases: []
+displayName: Jeomseon Unity GameObject Pooling Ownership
+description: >-
+  Generated owner-lifetime management for pooled GameObjects and Components.
+repoUrl: https://github.com/jeomseon0516/Unity.GameObjectPooling.Ownership
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - utilities
+hunter: jeomseon0516
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.0
+readme: main:README.md
+createdAt: 1789140246941

--- a/data/packages/com.jeomseon.unity.ownership.yml
+++ b/data/packages/com.jeomseon.unity.ownership.yml
@@ -1,0 +1,19 @@
+name: com.jeomseon.unity.ownership
+aliases: []
+displayName: Jeomseon Unity Ownership
+description: >-
+  Ownership contracts, lifetime hosting, source generation, and diagnostics for Unity resources.
+repoUrl: https://github.com/jeomseon0516/Unity.Ownership
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - utilities
+hunter: jeomseon0516
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.0
+readme: main:README.md
+createdAt: 1789140246941

--- a/data/packages/com.jeomseon.unity.reactive-ui.yml
+++ b/data/packages/com.jeomseon.unity.reactive-ui.yml
@@ -1,0 +1,20 @@
+name: com.jeomseon.unity.reactive-ui
+aliases: []
+displayName: Jeomseon Unity Reactive UI
+description: >-
+  UI Toolkit data-binding adapters for Jeomseon Unity Reactive fields and lists.
+repoUrl: https://github.com/jeomseon0516/Unity.ReactiveUI
+trackingMode: git
+parentRepoUrl: null
+licenseSpdxId: MIT
+licenseName: MIT License
+image: ''
+topics:
+  - gui
+  - utilities
+hunter: jeomseon0516
+gitTagPrefix: ''
+gitTagIgnore: ''
+minVersion: 0.1.0
+readme: main:README.md
+createdAt: 1789140246941


### PR DESCRIPTION
Registers five released Unity packages:

- com.jeomseon.unity.awaitable
- com.jeomseon.unity.ownership
- com.jeomseon.unity.addressables.ownership
- com.jeomseon.unity.game-object-pooling.ownership
- com.jeomseon.unity.reactive-ui

Each repository has a matching release tag and Unity package manifest.